### PR TITLE
A small change to allow extra keyword arguments to be passed to sqlite3.connect()

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -20,11 +20,12 @@ logger = logging.getLogger('peewee.logger')
 
 
 class Database(object):
-    def __init__(self, database):
+    def __init__(self, database, connect_kwargs=None):
         self.database = database
+        self.connect_kwargs = connect_kwargs if connect_kwargs else {}
     
     def connect(self):
-        self.conn = sqlite3.connect(self.database)
+        self.conn = sqlite3.connect(self.database, **self.connect_kwargs)
     
     def close(self):
         self.conn.close()


### PR DESCRIPTION
Thanks for a great little ORM. It does exactly what I need, without getting in the way.

This pull request encompasses two small changes. The first is to use the Python 2.5 style ternary in place of the custom lambda. The second (and more important to me) change is to allow arbitrary keyword arguments to be passed to sqlite3.connect().
