### PR TITLE
Proposed fix for sqlite syntax error when model field is named group

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1800,7 +1800,7 @@ class Field(object):
     
     def to_sql(self):
         rendered = self.render_field_template()
-        return '%s %s' % (self.name, rendered)
+        return '"%s" %s' % (self.name, rendered)
     
     def null_wrapper(self, value, default=None):
         if (self.null and value is None) or default is None:


### PR DESCRIPTION
Just thought Id send this pull request so you dont have to edit it yourself or look up the line/method I was referencing in the issue for the operationalError/syntax error.
