### PR TITLE
CharField to return unicode value

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1882,6 +1882,9 @@ class CharField(Field):
         else:
             return self.db_value(value)
     
+    def python_value(self, value):
+        return value.decode('utf-8')
+    
 
 class TextField(Field):
     db_field = 'text'


### PR DESCRIPTION
Should CharField be utf-8 decoded? It resolves errors I had with flask-peewee.
