### PR TITLE
Allow foreign key select fields to be set in Meta config

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2071,12 +2071,12 @@ class ForeignRelatedObject(object):
             return self.field
 
         if not getattr(instance, self.cache_name, None):
+            id = getattr(instance, self.field_column, 0)
             if hasattr(self.to._meta, 'fk_select'):
                 select = self.to._meta.fk_select
             else:
-                select = ['*',]
-            id = getattr(instance, self.field_column, 0)
-            qr = self.to.select().where(**{self.to._meta.pk_name: id})
+                select = None
+            qr = self.to.select(select).where(**{self.to._meta.pk_name: id})
             try:
                 setattr(instance, self.cache_name, qr.get())
             except self.to.DoesNotExist:


### PR DESCRIPTION
Basically as it says, 

I ran into the problem that unnecessary data tied to a model was being returned during the FK selection and since most of my FK lookups are parsed and directly outputted to an API performing an inline filter for these unwanted fields on a case by case basis would be cumbersome and error prone.

So I just hacked into peewee and put it in the Models Meta config to allow for this, I am not 100% if it needed to go both in the _ForeignRelatedObject_ & _ReverseForeignRelatedObject_ so I just stuck it in _ForeignRelatedObject_.

Below is an example

```
class User(Model):

    class Meta:
        db_table = 'user'
        fk_select = ['username', 'email', 'id']

    id = PrimaryKeyField(db_index = True)
    email = CharField(db_index = True, unique = True)
    password = CharField()
    username = CharField(unique = True, null = True)
    verified = BooleanField(null = True)
    verification_code = CharField(null = True)
```

Also note sure if this has gone into the latest already but I have reconstructed the "R" objects to work as "Q" objects in the sense you can join them using "&" and  "|" syntax which proved very helpful to me when writing some more complex queries, this is not in my fork but if you are interested just let me know.
