### PR TITLE
Avoid error when returning non-ascii characters from __unicode__ method

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2466,7 +2466,7 @@ class BaseModel(type):
             field.class_prepared()
 
         if hasattr(cls, '__unicode__'):
-            setattr(cls, '__repr__', lambda self: '<%s: %s>' % (
+            setattr(cls, '__repr__', lambda self: '<%s: %r>' % (
                 _meta.model_name, self.__unicode__()))
 
         exception_class = type('%sDoesNotExist' % _meta.model_name, (DoesNotExist,), {})


### PR DESCRIPTION
The **repr** methods just tries to cast the unicode to str, which fails when non-ascii characters are present.
