### PR TITLE
Change documentation link in README to point to RTD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ You can use django-style syntax to create select queries::
 Learning more
 -------------
 
-check the `documentation <http://charlesleifer.com/docs/peewee/>`_ for more
+check the `documentation <http://peewee.readthedocs.org/>`_ for more
 examples.
 
 specific question?  come hang out in the #peewee channel on freenode.irc.net,


### PR DESCRIPTION
[RTD](http://peewee.readthedocs.org/en/latest/index.html) had a newer version of the documentation, and is linked from the github description, so I assumed that's the canonical doc location.
