### PR TITLE
Fixed thread_locals not actually working.

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -282,7 +282,7 @@ class Database(object):
     def __init__(self, adapter, database, threadlocals=False, autocommit=True, **connect_kwargs):
         self.adapter = adapter
         self.init(database, **connect_kwargs)
-        self.threadlocals = connect_kwargs.get('threadlocals', False)
+        threadlocals = connect_kwargs.get('threadlocals', False)
 
         if threadlocals:
             self.__local = threading.local()


### PR DESCRIPTION
Cheap fix that you may feel like rewriting to actually trace back to the problem. The thread_locals var was being passed in as connect_kwargs as opposed to the keyword. 

Again, this is probably just a temporary fix.
