### PR TITLE
Add support for primary foreign keys

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1549,7 +1549,8 @@ class Database(object):
         return self.execute_sql(qc.create_index(model_class, field_objs, unique))
 
     def create_foreign_key(self, model_class, field):
-        return self.create_index(model_class, [field], field.unique)
+        if not field.primary_key:
+            return self.create_index(model_class, [field], field.unique)
 
     def create_sequence(self, seq):
         if self.sequences:


### PR DESCRIPTION
This commit adds support for foreign keys that are also primary keys, the preferred means of representing one-to-zero-or-one relationships between model classes. (The alternative representation wastes a column and an index.) This kind relationship is common in modeling schemes for inheritance or extension semantics.
