### PR TITLE
IN operator and subqueries

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -389,6 +389,9 @@ class SelectTestCase(BasePeeweeTestCase):
         sq = SelectQuery(User).where(User.id << User.select().where(User.username=='u1'))
         self.assertWhere(sq, '(users."id" IN (SELECT users."id" FROM "users" AS users WHERE (users."username" = ?)))', ['u1'])
 
+        sq = SelectQuery(User).where(User.username << User.select(User.username).where(User.username=='u1'))
+        self.assertWhere(sq, '(users."username" IN (SELECT users."username" FROM "users" AS users WHERE (users."username" = ?)))', ['u1'])
+
         sq = SelectQuery(Blog).where((Blog.pk == 3) | (Blog.user << User.select().where(User.username << ['u1', 'u2'])))
         self.assertWhere(sq, '((blog."pk" = ?) OR (blog."user_id" IN (SELECT users."id" FROM "users" AS users WHERE (users."username" IN (?,?)))))', [3, 'u1', 'u2'])
 


### PR DESCRIPTION
This patch allows you to make a query with an IN operator where the subquery return another field than the "id".

For example, I have this two models:

``` python
    class Customer(Model):
        cust_number = IntegerField()
        name = CharField()
     ....

    class AccountLog(Model):
        name = CharField()
        internal_number = IntegerField() # this number is filled with the cust_number
    .....
```

and I want to obtain all the Customers who doesn't have an account created. 
This query resolve the problem

``` python
    created_accounts = AccountLog.select(AccountLog.internal_number)
    q = Customer.select().where(~(Customer.cust_number << created_accounts))
```

With this patch, the resulting SQL is:

``` SQL
SELECT t1."id", t1."cust_number", t1."name"  
FROM "customer" AS t1 
WHERE NOT (t1."cust_number" IN (
        SELECT t2."internal_number" 
        FROM "accountlog" AS t2))
```

Sorry for my English.... 
