### PR TITLE
SelectQuery.first()

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1288,6 +1288,13 @@ class SelectQuery(Query):
                 self.sql(self.database.get_compiler())
             ))
 
+    def first(self):
+        clone = self.limit(1)
+        try:
+            return clone.execute().next()
+        except StopIteration:
+            return None
+
     def sql(self, compiler):
         return compiler.parse_select_query(self)
 


### PR DESCRIPTION
Return the first result of a Query or `None` if the result doesn't contain any row. This is analogous to SQLAlchemy and python-mongodb and eases portability for third-party modules wanting to support peewee.
