### PR TITLE
Alled for old style mysql no FK relation

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -718,8 +718,12 @@ class QueryCompiler(object):
                     right_field = to_model._meta.primary_key.db_column
                 else:
                     field = to_model._meta.rel_for_model(from_model, join.on)
-                    left_field = from_model._meta.primary_key.db_column
-                    right_field = field.db_column
+                    if field is not None:
+                        left_field = from_model._meta.primary_key.db_column
+                        right_field = field.db_column
+                    else:
+                        left_field = from_model._meta.primary_key.db_column
+                        right_field = join.on.lhs.db_column
 
                 join_type = join.join_type or JOIN_INNER
                 lhs = '%s.%s' % (alias_map[from_model], self.quote(left_field))


### PR DESCRIPTION
Hi there, we have a very old db that has no FKs defined.

Currently its not possible (or seems not) to perform joins on elements that have no FK

This is a minor patch for it.. 
