### PR TITLE
Makes script useable with legacy sqlite dbs which have no foreign keys

### DIFF
--- a/pwiz.py
+++ b/pwiz.py
@@ -234,8 +234,7 @@ class SqDB(DB):
         try:
             columns = re.search('\((.+)\)', table_def).groups()[0]
         except AttributeError:
-            err('Unable to read table definition for "%s"' % table)
-            sys.exit(1)
+            return fks
 
         for col_def in columns.split(','):
             col_def = col_def.strip()


### PR DESCRIPTION
I had this issue specifically on this db: https://github.com/jasonh-n-austin/WheelsREST/blob/master/wheels.db
This is an export from an older MS Sql Server db, which did not have any foreign keys on tables etc. This error handling for foreign keys made it instantly quit with 'Unable to read table definition for "rides"'. 
Handling this quietly doesn't seem to hurt anything, as it generated models for all of the tables, it just didn't apply any treatment for fks.
