### PR TITLE
Launch example app with env

### DIFF
--- a/example/run_example.py
+++ b/example/run_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 sys.path.insert(0, '..')


### PR DESCRIPTION
Using env rather than launching python directly facilitates
the use of virtualenv.
