### PR TITLE
save field_dict len validation.

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2335,7 +2335,10 @@ class Model(with_metaclass(BaseModel)):
         return new_data
 
     def save(self, force_insert=False, only=None):
-        field_dict = dict(self._data)
+        field_dict = dict(self._data)        
+        if not len(field_dict):
+            raise AttributeError('Cannot save: \'%s\' instance has no assigned fields' % 
+                                (self._meta.name))
         pk = self._meta.primary_key
         if only:
             field_dict = self._prune_fields(field_dict, only)


### PR DESCRIPTION
Running this code:

> > > x = ModelInstance()
> > > x.save()  

Trigger this:

```
 1719     def execute_sql(self, sql, params=None, require_commit=True):
   1720         cursor = self.get_cursor()
-> 1721         res = cursor.execute(sql, params or ())
   1722         if require_commit and self.get_autocommit():
   1723             self.commit()

OperationalError: near ")": syntax error
```
