### PR TITLE
OR operator in multiple where conditions

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2343,10 +2343,7 @@ class Model(with_metaclass(BaseModel)):
         return new_data
 
     def save(self, force_insert=False, only=None):
-        field_dict = dict(self._data)        
-        if not len(field_dict):
-            raise AttributeError('Cannot save: \'%s\' instance has no assigned fields' % 
-                                (self._meta.name))
+        field_dict = dict(self._data)
         pk = self._meta.primary_key
         if only:
             field_dict = self._prune_fields(field_dict, only)


### PR DESCRIPTION
Currently is not possible to specify the operator kind between multiple WHERE conditions, AND condition is assumed:

``` sql
WHERE ((((t2."kind" = ?) AND (t2."value" <= ?)) *OR* ((t2."kind" = ?) AND (t2."value" <= ?))) AND (t1."state" = ?))
```

Now is possible to specify the operator for each WHERE condition, using the op=(peewee.OP_OR, peewee.OP_AND)

``` python
q = Foo.select()

for i, val in conditions:
     q = q.where((Foo.i == val), op=peewee.OP_OR)
```
