### PR TITLE
Added kwargs to ModelOptions for further customization

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2426,8 +2426,12 @@ class Model(with_metaclass(BaseModel)):
             ).where(pk == self.get_id())
             update.execute()
         else:
+            if self.get_id() is not None:
+                new_pk = self.get_id()
             insert = self.insert(**field_dict)
-            new_pk = insert.execute()
+            ret_pk = insert.execute()
+            if ret_pk is not None:
+                new_pk = ret_pk
             self.set_id(new_pk)
 
     def dependencies(self, search_nullable=False):


### PR DESCRIPTION
This allows people to add more options to the model, for example if used with a serializer that looks for excluded fields:

```
class User(Model):
    class Meta:
        excludes = ['id']
```

The kwargs that would be used is unique for each use case.
