### PR TITLE
Dirty Flag

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2751,6 +2751,7 @@ class Model(with_metaclass(BaseModel)):
     def is_dirty(self):
         return bool(self._dirty)
 
+    @property
     def dirty_fields(self):
         return [f for f in self._meta.get_fields() if f.name in self._dirty]
 

--- a/tests.py
+++ b/tests.py
@@ -1733,7 +1733,7 @@ class ModelAPITestCase(ModelTestCase):
 
         u.username = 'u2'
         self.assertTrue(u.is_dirty())
-        self.assertEqual(u.dirty_fields(), [User.username])
+        self.assertEqual(u.dirty_fields, [User.username])
 
         u.save()
         self.assertFalse(u.is_dirty())


### PR DESCRIPTION
Update all fields on saving will increase probability of `lost update`.
Such as: 

TransactionA do not update username field
TransactionB update username field
TransactionB save
TransactionA save. 

then we will lost username modification in TransactionB.
But if we just update necessary fields without username in TransactionA, it's okay.

we can easily call `model.save(only=model.dirty_fields)` to fix that.
