### PR TITLE
Default logger handler if none is specified

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -77,7 +77,8 @@ except ImportError:
             pass
         
 # All peewee-generated logs are logged to this namespace.
-logger = logging.getLogger('peewee').addHandler(NullHandler())
+logger = logging.getLogger('peewee')
+logger.addHandler(NullHandler())
 
 # Python 2/3 compatibility helpers. These helpers are used internally and are
 # not exported.


### PR DESCRIPTION
This should stop showing warnings: "No handlers could be found for logger "peewee"" if no handler is specified.
