### PR TITLE
Fix `count`, refs #350: default count changed to COUNT(*)

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2057,7 +2057,7 @@ class SelectQuery(Query):
 
     def _aggregate(self, aggregation=None):
         if aggregation is None:
-            aggregation = fn.Count(self.model_class._meta.primary_key)
+            aggregation = fn.Count(SQL('*')) # self.model_class._meta.primary_key)
         query = self.order_by()
         query._select = [aggregation]
         return query

--- a/tests.py
+++ b/tests.py
@@ -1328,7 +1328,7 @@ class SugarTestCase(BasePeeweeTestCase):
 
     def test_aggregate(self):
         sq = User.select().where(User.id < 10)._aggregate()
-        self.assertSelect(sq, 'Count(users."id")', [])
+        self.assertSelect(sq, 'Count(*)', [])
         self.assertWhere(sq, '(users."id" < ?)', [10])
 
         sq = User.select()._aggregate(fn.Sum(User.id).alias('baz'))


### PR DESCRIPTION
Tests pass. Is there a strong reason to COUNT by primary keys rather than `COUNT(*)` ?
