### PR TITLE
Fix nullable UUID foreign keys

### DIFF
--- a/playhouse/postgres_ext.py
+++ b/playhouse/postgres_ext.py
@@ -167,7 +167,7 @@ class UUIDField(Field):
     db_field = 'uuid'
 
     def db_value(self, value):
-        return str(value)
+        return None if value is None else str(value) 
 
     def python_value(self, value):
         return uuid.UUID(value)


### PR DESCRIPTION
Hi guys,

Found a bug in the PostgresExt implementation of UUIDField for foreign keys. Let me know if the patch is satisfactory, it fixes my bug but not sure of the impact, would be great to get this in from my point of view :)

Example:

``` python
class Entity(Model):
    uuid = UUIDField(primary_key=True)
    name = CharField()

class User(Model):
    name = CharField()
    entity = ForeignKeyField(Entity, related_name="users", null=True)


User.create(name="Joe")
user = User.select().where(name="Joe").first()
user.name = "Barry"
user.save() # See error below..
```

Obviously a user **may** belong to a entity. I get this with the current implementation :(

```
Traceback (most recent call last):
 ... <redacted>
  File "/Users/alexlatchford/Code/abbreviate/a8-product/a8_product/../a8_product/database/__init__.py", line 77, in save
    return super(MetaBaseModel, self).save(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/peewee.py", line 3106, in save
    rows = self.update(**field_dict).where(self.pk_expr()).execute()
  File "/Library/Python/2.7/site-packages/peewee.py", line 2140, in execute
    return self.database.rows_affected(self._execute())
  File "/Library/Python/2.7/site-packages/peewee.py", line 1796, in _execute
    return self.database.execute_sql(sql, params, self.require_commit)
  File "/Library/Python/2.7/site-packages/playhouse/postgres_ext.py", line 255, in execute_sql
    self.commit()
  File "/Library/Python/2.7/site-packages/peewee.py", line 2234, in __exit__
    reraise(new_type, new_type(*exc_value.args), traceback)
  File "/Library/Python/2.7/site-packages/playhouse/postgres_ext.py", line 248, in execute_sql
    res = cursor.execute(sql, params or ())
DataError: invalid input syntax for uuid: "None"
LINE 1: ...'c8c4bb1aba234033b57d30b433f03354', "entity_id" = 'None', "i...
```

Many thanks,
Alex

PS. That example should work, my current one is a little bit more complicated than this so I had to write the example on the fly to simplify it down, apologies if it doesn't. You get the gist :)
