### PR TITLE
UUID fixes

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1250,7 +1250,9 @@ class QueryCompiler(object):
         elif isinstance(node, Model):
             sql = self.interpolation
             if conv and isinstance(conv, ForeignKeyField):
-                params = [getattr(node, conv.to_field.name)]
+                params = [
+                    conv.to_field.db_value(getattr(node, conv.to_field.name))
+                ]
             else:
                 params = [node.get_id()]
         elif isclass(node) and issubclass(node, Model):

--- a/playhouse/postgres_ext.py
+++ b/playhouse/postgres_ext.py
@@ -174,7 +174,7 @@ class UUIDField(Field):
         return None if value is None else str(value)
 
     def python_value(self, value):
-        return uuid.UUID(value)
+        return None if value is None else uuid.UUID(value)
 
 
 OP_HKEY = 'key'


### PR DESCRIPTION
Hi Charles,

Found another couple of bugs in the UUID implementation.
1. Finish off the UUIDField ForeignKeyField fixes, forgot to do the python_value implementation.. `UUID(None)` fails hard :(
2. Using a model as a query param fails for UUID primary key models with the following error:

```
[16/Jul/2014:10:05:35] HTTP Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/cherrypy/_cprequest.py", line 656, in respond
    response.body = self.handler()
  File "/Library/Python/2.7/site-packages/cherrypy/lib/encoding.py", line 188, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/cherrypy/_cpdispatch.py", line 34, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/Users/alexlatchford/Code/abbreviate/a8-product/a8_product/../a8_product/routes/external_api/v1/summaries.py", line 190, in POST
    db_image = SummaryImage.get(SummaryImage.summary == db_summary, SummaryImage.src == image['src'])
  File "/Library/Python/2.7/site-packages/peewee.py", line 3049, in get
    return sq.get()
  File "/Library/Python/2.7/site-packages/peewee.py", line 2093, in get
    return clone.execute().next()
  File "/Library/Python/2.7/site-packages/peewee.py", line 2132, in execute
    self._qr = ResultWrapper(model_class, self._execute(), query_meta)
  File "/Library/Python/2.7/site-packages/peewee.py", line 1838, in _execute
    return self.database.execute_sql(sql, params, self.require_commit)
  File "/Library/Python/2.7/site-packages/playhouse/postgres_ext.py", line 255, in execute_sql
    self.commit()
  File "/Library/Python/2.7/site-packages/peewee.py", line 2283, in __exit__
    reraise(new_type, new_type(*exc_value.args), traceback)
  File "/Library/Python/2.7/site-packages/playhouse/postgres_ext.py", line 248, in execute_sql
    res = cursor.execute(sql, params or ())
ProgrammingError: can't adapt type 'UUID'
```

I think this example should demonstrate the problem!

``` python
from peewee import *
from playhouse.postgres_ext import *
from uuid import UUID

class SomeModelA(Model):
    uuid = UUIDField(primary_key=True)

class SomeModelB(Model):
    name = CharField()
    some_model_a = ForeignKeyField(SomeModelA)

# Create and populate the tables etc..

some_model_a = SomeModelA.get(SomeModelA.uuid == UUID('<uuid>'))
some_model_b = SomeModelB.get(SomeModelB.some_model_a == some_model_a)
# throws ProgrammingError
```

Thanks,
Alex
