### PR TITLE
Add support for conditional saving model.

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -317,15 +317,18 @@ Models
 
         :rtype: Boolean whether the table for this model exists in the database
 
-    .. py:method:: save([force_insert=False[, only=None]])
+    .. py:method:: save([force_insert=False[, only=None[, conditions=[]]]])
 
         :param bool force_insert: Whether to force execution of an insert
         :param list only: A list of fields to persist -- when supplied, only the given
             fields will be persisted.
+        :param list conditions: A list of conditions to append to the ``where`` statement
+            when updating existing record.
 
         Save the given instance, creating or updating depending on whether it has a
         primary key.  If ``force_insert=True`` an ``INSERT`` will be issued regardless
-        of whether or not the primary key exists.
+        of whether or not the primary key exists. If extra ``conditions`` are not met,
+        record will not be updated. This is useful to detect write conflicts.
 
         Example showing saving a model instance:
 

--- a/peewee.py
+++ b/peewee.py
@@ -3246,7 +3246,7 @@ class Model(with_metaclass(BaseModel)):
                 new_data[field.name] = field_dict[field.name]
         return new_data
 
-    def save(self, force_insert=False, only=None):
+    def save(self, force_insert=False, only=None, conditions=[]):
         field_dict = dict(self._data)
         pk_field = self._meta.primary_key
         if only:
@@ -3256,7 +3256,7 @@ class Model(with_metaclass(BaseModel)):
                 field_dict.pop(pk_field.name, None)
             else:
                 field_dict = self._prune_fields(field_dict, self.dirty_fields)
-            rows = self.update(**field_dict).where(self.pk_expr()).execute()
+            rows = self.update(**field_dict).where(self.pk_expr(), *conditions).execute()
         else:
             pk = self.get_id()
             pk_from_cursor = self.insert(**field_dict).execute()

--- a/tests.py
+++ b/tests.py
@@ -2425,6 +2425,20 @@ class ModelAPITestCase(ModelTestCase):
         self.assertEqual(b_db.title, 'b2')
         self.assertEqual(b_db.content, '')
 
+    def test_save_conditional(self):
+        self.assertEqual(User.select().count(), 0)
+
+        u = User(username='u1')
+        self.assertEqual(u.save(), 1)
+        u.username = 'u2'
+        self.assertEqual(u.save(conditions=[User.username=="u1"]), 1)
+        self.assertEqual(u.save(conditions=[User.username=="u1"]), 0)
+
+        self.assertEqual(User.select().count(), 1)
+
+        self.assertEqual(u.delete_instance(), 1)
+        self.assertEqual(u.save(), 0)
+
     def test_zero_id(self):
         if isinstance(test_db, MySQLDatabase):
             # Need to explicitly tell MySQL it's OK to use zero.


### PR DESCRIPTION
Concurrent nodes of an application attempting to update the same record might result in data corruption/loss. To help with this scenario, this PR adds an optional `conditions` parameter on `Model.Save`. When the conditions are not met, updated record count will be `0` letting the application know the failure.
