### PR TITLE
Adding PyMySQL to the error message

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2773,7 +2773,7 @@ class MySQLDatabase(Database):
 
     def _connect(self, database, **kwargs):
         if not mysql:
-            raise ImproperlyConfigured('MySQLdb must be installed.')
+            raise ImproperlyConfigured('Either MySQLdb or PyMySQL must be installed.')
         conn_kwargs = {
             'charset': 'utf8',
             'use_unicode': True,


### PR DESCRIPTION
Since `peewee` supports both `MySQLdb` and `PyMySQL` modules, it makes sense to report them both at the error message.
