### PR TITLE
Add in support for passing in JSON dumps functions

### DIFF
--- a/docs/peewee/playhouse.rst
+++ b/docs/peewee/playhouse.rst
@@ -603,12 +603,14 @@ postgres_ext API notes
 
         Query rows for the existince of *any* key.
 
-.. py:class:: JSONField(*args, **kwargs)
+.. py:class:: JSONField(dumps=None, *args, **kwargs)
 
     Field class suitable for storing and querying arbitrary JSON.  When using
     this on a model, set the field's value to a Python object (either a `dict`
     or a `list`).  When you retrieve your value from the database it will be
     returned as a Python data structure.
+
+    :param dumps: The default is to call json.dumps() or the dumps function. You can override this method to create a customized JSON wrapper.
 
     .. note:: You must be using Postgres 9.2 / psycopg2 2.5 or greater.
 

--- a/playhouse/postgres_ext.py
+++ b/playhouse/postgres_ext.py
@@ -155,13 +155,15 @@ class HStoreField(IndexedField):
 class JSONField(Field):
     db_field = 'json'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, dumps=None, *args, **kwargs):
         if Json is None:
             raise Exception('Your version of psycopg2 does not support JSON.')
+
+        self.dumps = dumps
         super(JSONField, self).__init__(*args, **kwargs)
 
     def db_value(self, value):
-        return Json(value)
+        return Json(value, dumps=self.dumps)
 
     def __getitem__(self, value):
         return JsonLookup(self, [value])


### PR DESCRIPTION
Hi Charles,

I've added in support for passing through a `json.dumps` function to psycopg2. I need it to serialise datetime formats going into the db, but obviously this is nice and generic.

Let me know what you think.

Cheers,
Alex
