### PR TITLE
Fix typo.

### DIFF
--- a/docs/peewee/querying.rst
+++ b/docs/peewee/querying.rst
@@ -179,7 +179,7 @@ Instead, you can update the counters atomically using :py:meth:`~Model.update`:
 .. code-block:: pycon
 
     >>> query = Stat.update(counter=Stat.counter + 1).where(Stat.url == request.url)
-    >>> query.update()
+    >>> query.execute()
 
 You can make these update statements as complex as you like. Let's give all our employees a bonus equal to their previous bonus plus 10% of their salary:
 


### PR DESCRIPTION
```
>       query.update()
E       AttributeError: 'UpdateQuery' object has no attribute 'update'
1 failed, 27 passed in 3.69 seconds
```
