### PR TITLE
Fix typo in db_url.py

### DIFF
--- a/playhouse/db_url.py
+++ b/playhouse/db_url.py
@@ -50,7 +50,7 @@ def connect(url):
     if parsed.hostname:
         connect_kwargs['host'] = parsed.hostname
     if parsed.port:
-        connect_kwargs['post'] = parsed.port
+        connect_kwargs['port'] = parsed.port
 
     # Adjust parameters for MySQL.
     if database_class is MySQLDatabase and 'password' in connect_kwargs:


### PR DESCRIPTION
This was breaking on Heroku with the following error:

```
peewee.OperationalError: invalid connection option "post"
```

I checked the source code to see where this `"post"` was coming from, and here it was!
