### PR TITLE
Fixed issue with aggregate_rows

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1996,7 +1996,7 @@ class AggregateQueryResultWrapper(ModelQueryResultWrapper):
                         setattr(instance, foreign_key.name, joined_inst)
                         instances.append(joined_inst)
                 else:
-                    backref = current._meta.reverse_rel_for_model(join.dest)
+                    backref = current._meta.reverse_rel_for_model(join.dest, join.on)
                     if not backref:
                         continue
 
@@ -3424,8 +3424,8 @@ class ModelOptions(object):
                 if field_obj is None or field_obj.name == field.name:
                     return field
 
-    def reverse_rel_for_model(self, model):
-        return model._meta.rel_for_model(self.model_class)
+    def reverse_rel_for_model(self, model, field_obj=None):
+        return model._meta.rel_for_model(self.model_class, field_obj)
 
     def rel_exists(self, model):
         return self.rel_for_model(model) or self.reverse_rel_for_model(model)


### PR DESCRIPTION
Hi there.

Awesome job on this ORM!

I ran into an issue while using it last night, however, and here is my proposed solution. As not the most seasoned Python developer, your code is quite difficult for me to understand, so I don't know if this implemented correctly or if the change is even warranted. Perhaps I was using Peewee incorrectly.

My issue was as follows. I have ModelB with two foreign keys both to ModelA.

**Example:**

``` python
class ModelB(Model):
    manager = ForeignKeyField(ModelA, related_name='slaves')
    assistant = ForeignKeyField(ModelA, related_name='masters')
```

Using aggregate_rows to preload an instance of ModelA with its masters would place the results under the wrong related_field, slaves, for instance. I thought this might be because Peewee was handling this case incorrectly, and from what I understand about the code, the "rel_for_model" function accounts for this if you pass the field_obj argument, though that's not being passed through the calls to "reverse_rel_for_model", and so it's not really caring about the exact foreign key field and thus populating the wrong "related_name" field.

Does that make any sense?
