### PR TITLE
fix playhouse.migrate docstring about drop_index

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -97,7 +97,7 @@ Adding an index:
 Dropping an index:
 
     # Specify the index name.
-    migrate(migrator.drop_index('story_pub_date_status'))
+    migrate(migrator.drop_index('story', 'story_pub_date_status'))
 """
 from collections import namedtuple
 import functools


### PR DESCRIPTION
`migrator.drop_index` seems to require table name as the first argument. But module docstring showed just `.drop_index(index_name)`.
