### PR TITLE
Fix error when aggregating results that JOIN many-to-many tables

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1959,7 +1959,10 @@ class AggregateQueryResultWrapper(ModelQueryResultWrapper):
         _constructed = self.construct_instances(row)
         primary_instance = _constructed[self.model]
         for model_class, instance in _constructed.items():
-            identity_map[model_class] = {instance._get_pk_value(): instance}
+            pk_value = instance._get_pk_value()
+            if isinstance(pk_value, list):
+                pk_value = '-'.join([str(v) for v in pk_value])
+            identity_map[model_class] = {pk_value: instance}
 
         model_data = self.read_model_data(row)
         while True:
@@ -1984,6 +1987,8 @@ class AggregateQueryResultWrapper(ModelQueryResultWrapper):
                 # Do not include any instances which are comprised solely of
                 # NULL values.
                 pk_value = instance._get_pk_value()
+                if isinstance(pk_value, list):
+                    pk_value = '-'.join([str(v) for v in pk_value])
                 if [val for val in instance._data.values() if val is not None]:
                     identity_map[model_class][pk_value] = instance
 


### PR DESCRIPTION
Composite key is a list of primary keys in how the pk_value was being generated causing a crash when trying to be used as a dictionary key since a list isn't hashable.

Now it looks to see if it's a list, if it is, it casts the values to strings and concatenates them together with a dash.
