### PR TITLE
Support for filtering by joined table outside of select

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2018,10 +2018,13 @@ class AggregateQueryResultWrapper(ModelQueryResultWrapper):
                 foreign_key = current._meta.rel_for_model(join.dest)
                 if foreign_key:
                     for pk, instance in identity_map[current].items():
-                        joined_inst = identity_map[join.dest][
-                            instance._data[foreign_key.name]]
-                        setattr(instance, foreign_key.name, joined_inst)
-                        instances.append(joined_inst)
+                        try:
+                            joined_inst = identity_map[join.dest][
+                                instance._data[foreign_key.name]]
+                            setattr(instance, foreign_key.name, joined_inst)
+                            instances.append(joined_inst)
+                        except KeyError:
+                            continue
                 else:
                     backref = current._meta.reverse_rel_for_model(
                         join.dest, join.on)
@@ -2032,17 +2035,20 @@ class AggregateQueryResultWrapper(ModelQueryResultWrapper):
                     for instance in identity_map[current].values():
                         setattr(instance, attr_name, [])
 
-                    for pk, instance in identity_map[join.dest].items():
-                        if pk is None:
-                            continue
-                        try:
-                            joined_inst = identity_map[current][
-                                instance._data[backref.name]]
-                        except KeyError:
-                            continue
+                    try:
+                        for pk, instance in identity_map[join.dest].items():
+                            if pk is None:
+                                continue
+                            try:
+                                joined_inst = identity_map[current][
+                                    instance._data[backref.name]]
+                            except KeyError:
+                                continue
 
-                        getattr(joined_inst, attr_name).append(instance)
-                        instances.append(instance)
+                            getattr(joined_inst, attr_name).append(instance)
+                            instances.append(instance)
+                    except KeyError:
+                        continue
 
                 stack.append(join.dest)
 


### PR DESCRIPTION
Filtering by a joined table that is not part of the select would cause a KeyError when using aggregate_rows.

Consider the following example models:

``` python
class Organization(Model):
    name = CharField()


class Job(Model):
    name = CharField()
    organization = ForeignKeyField(Organization)


class Employee(Model):
    name = CharField()
    organization = ForeignKeyField(Organization)
    job = ForeignKeyField(Job)
```

Setup some basic records like so:

``` python
testing = Organization.create(name='Testing Co.')
tester = Job.create(name='Tester', organization=testing)
Employee.create(name='Tester Guy', organization=testing, job=tester)
```

The below throws an unhandled KeyError because the second join that is used to filter is not included in the select. The intent of the query below is to eagerly load an organization and all its jobs based on an employee's name, but not to load the employee's data.

``` python
(Organization
 .select(Organization, Job)
 .join(Job)
 .switch(Organization)
 .join(Employee)
 .where(Employee.name == 'Tester Guy')
 .aggregate_rows()
 .get())
```

Adding the try/except after line 2036 fixes this.

The below throws an unhandled KeyError because the second join that is used to filter is not included in the select. The intent of the query below is to eagerly load an employee and all its jobs based on an organization's name, but not to load the organization's data.

``` python
(Employee
 .select(Employee, Job)
 .join(Job)
 .switch(Employee)
 .join(Organization)
 .where(Organization.name == 'Testing Co.')
 .aggregate_rows()
 .get())
```

Adding the try/except after line 2020 fixes this.
