### PR TITLE
Support for Expression-based joins when using aggregate_rows()

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -3527,7 +3527,11 @@ class ModelOptions(object):
     def rel_for_model(self, model, field_obj=None):
         for field in self.get_fields():
             if isinstance(field, ForeignKeyField) and field.rel_model == model:
-                if field_obj is None or field_obj.name == field.name:
+                if (
+                    field_obj is None or
+                    (isinstance(field_obj, Field) and field_obj.name == field.name) or
+                    (isinstance(field_obj, Expression) and field_obj._alias == field.name)
+                ):
                     return field
 
     def reverse_rel_for_model(self, model, field_obj=None):


### PR DESCRIPTION
Joining on an Expression when using aggregate_rows() would cause an error because rel_for_model only handles Fields.

Consider the following data models:

``` python
class Organization(BaseModel):
    name = CharField()


class Review(BaseModel):
    rating = IntegerField()
    organization = ForeignKeyField(Organization, related_name='reviews')
```

I want to query for an organization by ID and eagerly load its reviews that are higher than 3.

``` python
(Organization
 .select(Organization, Review)
 .join(Review, JOIN_LEFT_OUTER,
        on=((Review.organization == Organization.id) & (Review.rating > 3)).alias('organization'))
 .where(Organization.id == 1)
 .aggregate_rows())[0]
```

Note the usage of [0] because of #483. The above would fail because rel_for_model does not support Expressions. I am doing the filter on the join instead of the where, because the query should still pull organization data even if there are no reviews above the rating of 3.
