### PR TITLE
[fix] TypeError: host is an invalid keyword argument for this function

### DIFF
--- a/playhouse/db_url.py
+++ b/playhouse/db_url.py
@@ -56,4 +56,10 @@ def connect(url):
     if database_class is MySQLDatabase and 'password' in connect_kwargs:
         connect_kwargs['passwd'] = connect_kwargs.pop('password')
 
+    # Adjust parameters for SQLite
+    if (database_class is SqliteDatabase and 'host' in connect_kwargs and
+        not connect_kwargs["database"]):
+        connect_kwargs['database'] = connect_kwargs['host']
+        del connect_kwargs['host']
+
     return database_class(**connect_kwargs)


### PR DESCRIPTION
Try to fix this:

    self = <peewee.SqliteDatabase object at 0x7f79bbfcf950>, database = ':memory:'
    kwargs = {'host': file.db'}

    def _connect(self, database, **kwargs):
    >       conn = sqlite3.connect(database, **kwargs)
    E TypeError: 'host' is an invalid keyword argument for this function