### PR TITLE
playhouse.migration bug fix

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -361,7 +361,7 @@ class MySQLColumn(namedtuple('_Column', _column_attributes)):
         if self.is_pk:
             parts.append(SQL('PRIMARY KEY'))
         if self.extra:
-            parts.append(SQL(extra))
+            parts.append(SQL(self.extra))
         return Clause(*parts)
 
 


### PR DESCRIPTION
this variable was mis-labeled such that migrations crashed if any column contained extra attributes, like 'auto_increment'.  this fixes it