### PR TITLE
key renames

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -354,12 +354,8 @@ class MySQLColumn(namedtuple('_Column', _column_attributes)):
         parts = [
             Entity(column_name),
             SQL(self.definition)]
-        if self.is_unique:
-            parts.append(SQL('UNIQUE'))
         if not is_null:
             parts.append(SQL('NOT NULL'))
-        if self.is_pk:
-            parts.append(SQL('PRIMARY KEY'))
         if self.extra:
             parts.append(SQL(self.extra))
         return Clause(*parts)


### PR DESCRIPTION
MySQL does wierd things when altering the columns of unique or primary keys.  It acts as though the user is tring to duplicate the field, rather than simply changing / renaming it (see error messages below).  Dropping these keywords from the query gives us the descired outcome anyway (keys remain keys without need to reiterate their definition).  wasn't sure whether it was better to leave the code in and comment it out with an explanation or go the cleaner route...

Warning: Duplicate index 'old_id' defined on the table 'test.data'. This is deprecated and will be disallowed in a future release.

peewee.OperationalError: (1068, 'Multiple primary key defined')
