### PR TITLE
primary null values

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -387,6 +387,8 @@ class MySQLMigrator(SchemaMigrator):
     @operation
     def drop_not_null(self, table, column):
         column = self._get_column_definition(table, column)
+        if column.is_pk:
+            raise ValueError('Primary keys can not be null')
         return Clause(
             SQL('ALTER TABLE'),
             Entity(table),


### PR DESCRIPTION
MySQL does not allow primary key fields to be null.  while it silently swallows any request to allow null values, this library ought to point out the failure to users