### PR TITLE
Revert "Fix Model.create_table(fail_silently=True) if schema is used."

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -3762,7 +3762,7 @@ class Model(with_metaclass(BaseModel)):
 
     @classmethod
     def table_exists(cls):
-        return cls._meta.db_table in cls._meta.database.get_tables(schema=cls._meta.schema)
+        return cls._meta.db_table in cls._meta.database.get_tables()
 
     @classmethod
     def create_table(cls, fail_silently=False):


### PR DESCRIPTION
This commit introduces a regression by overwriting the `PostgresqlDatabase.get_tables()` default value for `schema`.

```python
(Pdb) db
<playhouse.pool.PooledPostgresqlExtDatabase object at 0xb620964c>
(Pdb) db.get_tables(schema=None)
[]
(Pdb) db.get_tables()
[u'migration', u'users']
```

One of the affected projects is https://github.com/cam-stitt/arnold
Basically migrations no longer go down.

@dkorduban sorry to ask for a revert, please provide and update the tests if you really want to fix this issue.

@coleifer please try to encourage the presence of tests in contributions :cry: 