### PR TITLE
default values

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -761,7 +761,9 @@ class Field(Node):
             ddl.append(SQL('NOT NULL'))
         if self.primary_key:
             ddl.append(SQL('PRIMARY KEY'))
-        if self.sequence:
+        if self.default:
+            ddl.append(SQL("DEFAULT '%s'" % self.default))
+        elif self.sequence:
             ddl.append(SQL("DEFAULT NEXTVAL('%s')" % self.sequence))
         if self.constraints:
             ddl.extend(self.constraints)


### PR DESCRIPTION
field default values were being ignored for column creations and modifications.  this change ensures that a field marked with a default value creates a default value in the db.  tested this change through the standard Model table creation and schema migrator add_column() function, in mysql and sqlite