### PR TITLE
In PostgresqlExtDatabase, respect the 'autorollback' option

### DIFF
--- a/playhouse/postgres_ext.py
+++ b/playhouse/postgres_ext.py
@@ -351,6 +351,8 @@ class PostgresqlExtDatabase(PostgresqlDatabase):
                 cursor.execute(sql, params or ())
             except Exception as exc:
                 logger.exception('%s %s', sql, params)
+                if self.get_autocommit() and self.autorollback:
+                    self.rollback()
                 if self.sql_error_handler(exc, sql, params, require_commit):
                     raise
             else:


### PR DESCRIPTION
First of all, thanks so much for Peewee! I ran across the problem described in #240, which was fixed by the addition of the `autorollback` database option.

I was setting `autorollback=True`, but still hitting the problem, and realized that the implementation of `execute_sql ` in `PostgresqlExtDatabase` (which I'm using) doesn't include the check to see if the transaction should be automatically rolled back if the query throws an exception. I just copied in the two lines from the parent `Database` class that do this.