### PR TITLE
Custom bindings for selection expressions

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -331,6 +331,7 @@ class Node(object):
     def __init__(self):
         self._negated = False
         self._alias = None
+        self._target = None
         self._ordering = None  # ASC or DESC.
 
     @classmethod
@@ -360,6 +361,10 @@ class Node(object):
     @returns_clone
     def alias(self, a=None):
         self._alias = a
+
+    @returns_clone
+    def target(self, t):
+        self._target = t
 
     @returns_clone
     def asc(self):
@@ -1902,7 +1907,7 @@ class ModelQueryResultWrapper(QueryResultWrapper):
                 attr = node.name
                 conv = node.python_value
             else:
-                key = constructor = self.model
+                key = constructor = node._target if node._target else self.model
                 if isinstance(node, Expression) and node._alias:
                     attr = node._alias
             column_map.append((key, constructor, attr, conv))

--- a/peewee.py
+++ b/peewee.py
@@ -331,7 +331,7 @@ class Node(object):
     def __init__(self):
         self._negated = False
         self._alias = None
-        self._target = None
+        self._bind_to = None
         self._ordering = None  # ASC or DESC.
 
     @classmethod
@@ -363,8 +363,13 @@ class Node(object):
         self._alias = a
 
     @returns_clone
-    def target(self, t):
-        self._target = t
+    def bind_to(self, bt):
+        """
+        Bind the results of an expression to a specific model type. Useful when adding
+        expressions to a select, where the result of the expression should be placed on
+        a joined instance.
+        """
+        self._bind_to = bt
 
     @returns_clone
     def asc(self):
@@ -1907,7 +1912,7 @@ class ModelQueryResultWrapper(QueryResultWrapper):
                 attr = node.name
                 conv = node.python_value
             else:
-                key = constructor = node._target if node._target else self.model
+                key = constructor = node._bind_to if node._bind_to else self.model
                 if isinstance(node, Expression) and node._alias:
                     attr = node._alias
             column_map.append((key, constructor, attr, conv))

--- a/playhouse/tests/test_models.py
+++ b/playhouse/tests/test_models.py
@@ -72,6 +72,18 @@ class TestQueryingModels(ModelTestCase):
             ('u4', 3),
         ])
 
+    def test_select_with_target(self):
+        self.create_users_blogs(1, 1)
+        blog = Blog.select(
+            Blog,
+            User,
+            (User.username == 'u0').alias('is_u0').target(User),
+            (User.username == 'u1').alias('is_u1').target(User)
+        ).join(User).get()
+
+        self.assertTrue(blog.user.is_u0)
+        self.assertTrue(blog.user.is_u1)
+
     def test_scalar(self):
         User.create_users(5)
 

--- a/playhouse/tests/test_models.py
+++ b/playhouse/tests/test_models.py
@@ -77,8 +77,8 @@ class TestQueryingModels(ModelTestCase):
         blog = Blog.select(
             Blog,
             User,
-            (User.username == 'u0').alias('is_u0').target(User),
-            (User.username == 'u1').alias('is_u1').target(User)
+            (User.username == 'u0').alias('is_u0').bind_to(User),
+            (User.username == 'u1').alias('is_u1').bind_to(User)
         ).join(User).get()
 
         self.assertTrue(blog.user.is_u0)

--- a/playhouse/tests/test_models.py
+++ b/playhouse/tests/test_models.py
@@ -82,7 +82,7 @@ class TestQueryingModels(ModelTestCase):
         ).join(User).get()
 
         self.assertTrue(blog.user.is_u0)
-        self.assertTrue(blog.user.is_u1)
+        self.assertFalse(blog.user.is_u1)
 
     def test_scalar(self):
         User.create_users(5)

--- a/playhouse/tests/test_models.py
+++ b/playhouse/tests/test_models.py
@@ -72,7 +72,7 @@ class TestQueryingModels(ModelTestCase):
             ('u4', 3),
         ])
 
-    def test_select_with_target(self):
+    def test_select_with_bind_to(self):
         self.create_users_blogs(1, 1)
         blog = Blog.select(
             Blog,


### PR DESCRIPTION
Currently there is no way to have the results of a selection sub expression land on a joined instance, instead of on the top level instance. Many times a model is expected to always have a field defined, even if it was inflated via a join.

Example:

```python
BlogEntry.select(
    BlogEntry, 
    User, 
    fn.Exists(Role.select(Role.id).where(
        Role.user == User.id,
        Role.role == 'admin'
    )).alias('is_admin').bind_to(User)
).join(User)
```

Here, we expect the `User` objects to always have `is_admin` defined, even if inflated via a join.