### PR TITLE
Add pwiz option to preserve original DB column order.

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -89,7 +89,7 @@ __all__ = [
 # Set default logging handler to avoid "No handlers could be found for logger
 # "peewee"" warnings.
 try:  # Python 2.7+
-    from logging import NullHandler
+    from logging import NullHandler, StreamHandler
 except ImportError:
     class NullHandler(logging.Handler):
         def emit(self, record):
@@ -97,7 +97,8 @@ except ImportError:
 
 # All peewee-generated logs are logged to this namespace.
 logger = logging.getLogger('peewee')
-logger.addHandler(NullHandler())
+logger.addHandler(StreamHandler())
+logger.setLevel(logging.ERROR)
 
 # Python 2/3 compatibility helpers. These helpers are used internally and are
 # not exported.
@@ -1744,6 +1745,7 @@ class QueryCompiler(object):
                 SQL('PRIMARY KEY'), EnclosedClause(*pk_cols)))
         for field in meta.get_fields():
             columns.append(self.field_definition(field))
+            logger.debug("creating field {} with sort key {} in table {}".format(field, field._sort_key, model_class))
             if isinstance(field, ForeignKeyField) and not field.deferred:
                 constraints.append(self.foreign_key_constraint(field))
 

--- a/peewee.py
+++ b/peewee.py
@@ -3251,7 +3251,8 @@ class PostgresqlDatabase(Database):
         query = """
             SELECT column_name, is_nullable, data_type
             FROM information_schema.columns
-            WHERE table_name = %s AND table_schema = %s"""
+            WHERE table_name = %s AND table_schema = %s
+            ORDER BY ordinal_position"""
         cursor = self.execute_sql(query, (table, schema))
         pks = set(self.get_primary_keys(table, schema))
         return [ColumnMetadata(name, dt, null == 'YES', name in pks, table)

--- a/peewee.py
+++ b/peewee.py
@@ -89,7 +89,7 @@ __all__ = [
 # Set default logging handler to avoid "No handlers could be found for logger
 # "peewee"" warnings.
 try:  # Python 2.7+
-    from logging import NullHandler, StreamHandler
+    from logging import NullHandler
 except ImportError:
     class NullHandler(logging.Handler):
         def emit(self, record):
@@ -97,8 +97,7 @@ except ImportError:
 
 # All peewee-generated logs are logged to this namespace.
 logger = logging.getLogger('peewee')
-logger.addHandler(StreamHandler())
-logger.setLevel(logging.ERROR)
+logger.addHandler(NullHandler())
 
 # Python 2/3 compatibility helpers. These helpers are used internally and are
 # not exported.
@@ -1745,7 +1744,6 @@ class QueryCompiler(object):
                 SQL('PRIMARY KEY'), EnclosedClause(*pk_cols)))
         for field in meta.get_fields():
             columns.append(self.field_definition(field))
-            logger.debug("creating field {} with sort key {} in table {}".format(field, field._sort_key, model_class))
             if isinstance(field, ForeignKeyField) and not field.deferred:
                 constraints.append(self.foreign_key_constraint(field))
 

--- a/playhouse/reflection.py
+++ b/playhouse/reflection.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 import re
 
 from peewee import *
@@ -135,7 +135,7 @@ class Metadata(object):
         return self.database.execute_sql(sql, params)
 
     def get_columns(self, table, schema=None):
-        metadata = dict(
+        metadata = OrderedDict(
             (metadata.name, metadata)
             for metadata in self.database.get_columns(table, schema))
 
@@ -149,7 +149,7 @@ class Metadata(object):
             if column_types[pk] is IntegerField:
                 column_types[pk] = PrimaryKeyField
 
-        columns = {}
+        columns = OrderedDict()
         for name, column_data in metadata.items():
             columns[name] = Column(
                 name,

--- a/playhouse/reflection.py
+++ b/playhouse/reflection.py
@@ -1,4 +1,9 @@
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
+try:
+    from collections import OrderedDict
+except ImportError:
+    OrderedDict = dict
+
 import re
 
 from peewee import *

--- a/playhouse/reflection.py
+++ b/playhouse/reflection.py
@@ -1,9 +1,9 @@
-from collections import namedtuple
 try:
     from collections import OrderedDict
 except ImportError:
     OrderedDict = dict
 
+from collections import namedtuple
 import re
 
 from peewee import *

--- a/playhouse/tests/test_pwiz.py
+++ b/playhouse/tests/test_pwiz.py
@@ -11,7 +11,7 @@ from pwiz import *
 from playhouse.tests.base import database_initializer
 from playhouse.tests.base import mock
 from playhouse.tests.base import PeeweeTestCase
-import logging
+
 
 db = database_initializer.get_database('sqlite')
 
@@ -112,10 +112,7 @@ class TestPwiz(PeeweeTestCase):
         if os.path.exists(db.database):
             os.unlink(db.database)
         db.connect()
-        logger = logging.getLogger("peewee")
-        logger.setLevel(logging.DEBUG)
         db.create_tables([User, Note, Category])
-        logger.setLevel(logging.ERROR)
         self.introspector = Introspector.from_database(db)
 
     def tearDown(self):

--- a/playhouse/tests/test_pwiz.py
+++ b/playhouse/tests/test_pwiz.py
@@ -126,10 +126,14 @@ class TestPwiz(PeeweeTestCase):
         self.assertEqual(output.data.strip(), EXPECTED)
 
     def test_print_models_order_preserved(self):
-        with capture_output() as output:
-            print_models(self.introspector, preserve_order=True)
+        try:
+            from collections import OrderedDict
+            with capture_output() as output:
+                print_models(self.introspector, preserve_order=True)
 
-        self.assertEqual(output.data.strip(), EXPECTED_PRESERVE_ORDER)
+            self.assertEqual(output.data.strip(), EXPECTED_PRESERVE_ORDER)
+        except ImportError:
+            pass  # Feature only supported for versions >= 2.7
 
     def test_print_header(self):
         cmdline = '-i -e sqlite /path/to/database.db'

--- a/playhouse/tests/test_pwiz.py
+++ b/playhouse/tests/test_pwiz.py
@@ -40,7 +40,7 @@ class capture_output(object):
         self.data = self._buffer.getvalue()
         sys.stdout = self._stdout
 
-EXPECTED_HEAD = """
+EXPECTED = """
 from peewee import *
 
 database = SqliteDatabase('peewee_test.db', **{})
@@ -52,15 +52,9 @@ class BaseModel(Model):
     class Meta:
         database = database
 
-class Category(BaseModel):"""
-
-EXPECTED_CAT_NAME = """
-    name = CharField(unique=True)"""
-
-EXPECTED_CAT_PARENT = """
-    parent = ForeignKeyField(db_column='parent_id', null=True, rel_model='self', to_field='id')"""
-
-EXPECTED_MID = """
+class Category(BaseModel):
+    name = CharField(unique=True)
+    parent = ForeignKeyField(db_column='parent_id', null=True, rel_model='self', to_field='id')
 
     class Meta:
         db_table = 'category'
@@ -71,35 +65,46 @@ class User(BaseModel):
     class Meta:
         db_table = 'user'
 
-class Note(BaseModel):"""
-
-EXPECTED_NOTE_TEXT = """
-    text = TextField(index=True)"""
-
-EXPECTED_NOTE_USER = """
-    user = ForeignKeyField(db_column='user_id', rel_model=User, to_field='username')"""
-
-EXPECTED_NOTE_END = """
+class Note(BaseModel):
+    text = TextField(index=True)
+    user = ForeignKeyField(db_column='user_id', rel_model=User, to_field='username')
 
     class Meta:
         db_table = 'note'
-"""
+""".strip()
 
-EXPECTED = (EXPECTED_HEAD +
-            EXPECTED_CAT_NAME +
-            EXPECTED_CAT_PARENT +
-            EXPECTED_MID +
-            EXPECTED_NOTE_TEXT +
-            EXPECTED_NOTE_USER +
-            EXPECTED_NOTE_END).strip()
+EXPECTED_PRESERVE_ORDER = """
+from peewee import *
 
-EXPECTED_PRESERVE_ORDER =  (EXPECTED_HEAD +
-                            EXPECTED_CAT_PARENT +
-                            EXPECTED_CAT_NAME +
-                            EXPECTED_MID +
-                            EXPECTED_NOTE_USER +
-                            EXPECTED_NOTE_TEXT +
-                            EXPECTED_NOTE_END).strip()
+database = SqliteDatabase('peewee_test.db', **{})
+
+class UnknownField(object):
+    pass
+
+class BaseModel(Model):
+    class Meta:
+        database = database
+
+class Category(BaseModel):
+    parent = ForeignKeyField(db_column='parent_id', null=True, rel_model='self', to_field='id')
+    name = CharField(unique=True)
+
+    class Meta:
+        db_table = 'category'
+
+class User(BaseModel):
+    username = CharField(primary_key=True)
+
+    class Meta:
+        db_table = 'user'
+
+class Note(BaseModel):
+    user = ForeignKeyField(db_column='user_id', rel_model=User, to_field='username')
+    text = TextField(index=True)
+
+    class Meta:
+        db_table = 'note'
+""".strip()
 
 class TestPwiz(PeeweeTestCase):
     def setUp(self):

--- a/playhouse/tests/test_pwiz.py
+++ b/playhouse/tests/test_pwiz.py
@@ -101,7 +101,6 @@ EXPECTED_PRESERVE_ORDER =  (EXPECTED_HEAD +
                             EXPECTED_NOTE_TEXT +
                             EXPECTED_NOTE_END).strip()
 
-
 class TestPwiz(PeeweeTestCase):
     def setUp(self):
         super(TestPwiz, self).setUp()

--- a/playhouse/tests/test_pwiz.py
+++ b/playhouse/tests/test_pwiz.py
@@ -11,7 +11,7 @@ from pwiz import *
 from playhouse.tests.base import database_initializer
 from playhouse.tests.base import mock
 from playhouse.tests.base import PeeweeTestCase
-
+import logging
 
 db = database_initializer.get_database('sqlite')
 
@@ -112,7 +112,10 @@ class TestPwiz(PeeweeTestCase):
         if os.path.exists(db.database):
             os.unlink(db.database)
         db.connect()
+        logger = logging.getLogger("peewee")
+        logger.setLevel(logging.DEBUG)
         db.create_tables([User, Note, Category])
+        logger.setLevel(logging.ERROR)
         self.introspector = Introspector.from_database(db)
 
     def tearDown(self):

--- a/pwiz.py
+++ b/pwiz.py
@@ -69,9 +69,12 @@ def print_models(introspector, tables=None):
                     _print_table(dest, seen, accum + [table])
 
         print_('class %s(BaseModel):' % database.model_names[table])
-        columns = database.columns[table]
+        columns = database.columns[table].items()
+        if not options.order_preserved:
+            columns = sorted(columns)  # order model columns alphabetically
         primary_keys = database.primary_keys[table]
-        for name, column in sorted(columns.items()):
+
+        for name, column in columns:
             skip = all([
                 name == 'id',
                 len(primary_keys) == 1,
@@ -92,7 +95,7 @@ def print_models(introspector, tables=None):
             print_('        schema = \'%s\'' % introspector.schema)
         if len(primary_keys) > 1:
             pk_field_names = sorted([
-                field.name for col, field in columns.items()
+                field.name for col, field in columns
                 if col in primary_keys])
             pk_list = ', '.join("'%s'" % pk for pk in pk_field_names)
             print_('        primary_key = CompositeKey(%s)' % pk_list)
@@ -138,6 +141,8 @@ def get_option_parser():
     ao('-i', '--info', dest='info', action='store_true',
        help=('Add database information and other metadata to top of the '
              'generated file.'))
+    ao('-o', '--order-preserved', action='store_true',
+       help=('Order columns in model definition to preserve order in source database'))
     return parser
 
 def get_connect_kwargs(options):

--- a/pwiz.py
+++ b/pwiz.py
@@ -156,6 +156,13 @@ if __name__ == '__main__':
     parser = get_option_parser()
     options, args = parser.parse_args()
 
+    if options.order_preserved:
+        try:
+            from collections import OrderedDict
+        except ImportError:
+            err('Preserve column order not supported for Python versions prior to 2.7')
+            sys.exit(1)
+
     if len(args) < 1:
         err('Missing required parameter "database"')
         parser.print_help()

--- a/pwiz.py
+++ b/pwiz.py
@@ -42,7 +42,7 @@ def make_introspector(database_type, database_name, **kwargs):
     db = DatabaseClass(database_name, **kwargs)
     return Introspector.from_database(db, schema=schema)
 
-def print_models(introspector, tables=None):
+def print_models(introspector, tables=None, preserve_order=False):
     database = introspector.introspect()
 
     print_(TEMPLATE % (
@@ -70,7 +70,7 @@ def print_models(introspector, tables=None):
 
         print_('class %s(BaseModel):' % database.model_names[table])
         columns = database.columns[table].items()
-        if not options.order_preserved:
+        if not preserve_order:
             columns = sorted(columns)  # order model columns alphabetically
         primary_keys = database.primary_keys[table]
 
@@ -174,4 +174,4 @@ if __name__ == '__main__':
         cmd_line = ' '.join(raw_argv[1:])
         print_header(cmd_line, introspector)
 
-    print_models(introspector, tables)
+    print_models(introspector, tables, preserve_order=options.order_preserved)

--- a/pwiz.py
+++ b/pwiz.py
@@ -141,7 +141,7 @@ def get_option_parser():
     ao('-i', '--info', dest='info', action='store_true',
        help=('Add database information and other metadata to top of the '
              'generated file.'))
-    ao('-o', '--order-preserved', action='store_true',
+    ao('-o', '--order-preserved', action='store_true', dest='preserve_order',
        help=('Order columns in model definition to preserve order in source database'))
     return parser
 
@@ -156,7 +156,7 @@ if __name__ == '__main__':
     parser = get_option_parser()
     options, args = parser.parse_args()
 
-    if options.order_preserved:
+    if options.preserve_order:
         try:
             from collections import OrderedDict
         except ImportError:
@@ -181,4 +181,4 @@ if __name__ == '__main__':
         cmd_line = ' '.join(raw_argv[1:])
         print_header(cmd_line, introspector)
 
-    print_models(introspector, tables, preserve_order=options.order_preserved)
+    print_models(introspector, tables, preserve_order=options.preserve_order)


### PR DESCRIPTION
Add pwiz option to preserve original DB column order in generated model definitions.  Very useful when a DB created by Peewee will be loaded from a dump file created with native DB tools (e.g. Postgresql INSERT type dump).