### PR TITLE
insert_many() + insert_returning support

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1676,7 +1676,7 @@ class QueryCompiler(object):
                     SQL('VALUES'),
                     CommaClause(*value_clauses)])
 
-        if meta.database.insert_returning and not query._is_multi_row_insert:
+        if meta.database.insert_returning:
             clauses.extend([
                 SQL('RETURNING'),
                 self._get_field_clause(
@@ -2760,6 +2760,8 @@ class InsertQuery(Query):
             else:
                 return self.database.last_insert_id(cursor, self.model_class)
         else:
+            if self.database.insert_returning:
+                return [row[0] for row in cursor.fetchall()]
             return True
 
 class DeleteQuery(Query):

--- a/playhouse/tests/test_queries.py
+++ b/playhouse/tests/test_queries.py
@@ -1011,11 +1011,21 @@ class TestInsertReturning(PeeweeTestCase):
             username = CharField()
 
         data = [{'username': 'user-%s' % i} for i in range(3)]
-        # Bulk inserts do not ask for returned primary keys.
         self.assertInsertSQL(
             User.insert_many(data),
-            'INSERT INTO "user" ("username") VALUES (?), (?), (?)',
+            'INSERT INTO "user" ("username") VALUES (?), (?), (?) RETURNING "id"',
             ['user-0', 'user-1', 'user-2'])
+
+    def test_insert_many_non_int_pk(self):
+        class User(self.BaseModel):
+            username = CharField(primary_key=True)
+            data = TextField(default='')
+
+        data = [{'username': 'user-%s' % i} for i in range(3)]
+        self.assertInsertSQL(
+            User.insert_many(data),
+            'INSERT INTO "user" ("username", "data") VALUES (?, ?), (?, ?), (?, ?) RETURNING "username"',
+            ['user-0', '', 'user-1', '', 'user-2', ''])
 
 
 class TestDeleteQuery(PeeweeTestCase):


### PR DESCRIPTION
I saw that there was support for RETURNING but only for single-row INSERTs, and I needed support for multi-row INSERTs with RETURNING as well.

Based on your tests, it looks like you may not have wanted to include this functionality. If that's the case, I'd be happy to make this a non-default option for `insert_many()` so that the default behavior is unchanged, but getting the primary keys of all new rows is available as an option for those who want it.

Otherwise, if this does seem like a good default behavior, then I've updated the tests and this should be good to merge.