### PR TITLE
Update pk seq

### DIFF
--- a/docs/peewee/models.rst
+++ b/docs/peewee/models.rst
@@ -478,6 +478,7 @@ Sometimes you do not want the database to automatically generate a value for the
             u.save(force_insert=True) # <-- force peewee to insert row
 
     User._meta.auto_increment = True
+    User.update_auto_pk()  # <--- force DB to ensure that next generated key will be > any existing key
 
 If you *always* want to have control over the primary key, simply do not use the :py:class:`PrimaryKeyField` field type, but use a normal :py:class:`IntegerField` (or other column type):
 

--- a/peewee.py
+++ b/peewee.py
@@ -3225,7 +3225,7 @@ class PostgresqlDatabase(Database):
     def last_insert_id(self, cursor, model):
         seq = self._get_pk_seq(model)
         if seq:
-            cursor.execute("SELECT CURRVAL(%s)" % (seq))
+            cursor.execute("SELECT CURRVAL('%s')" % (seq))
             result = cursor.fetchone()[0]
             if self.get_autocommit():
                 self.commit()

--- a/playhouse/tests/base.py
+++ b/playhouse/tests/base.py
@@ -46,7 +46,7 @@ if TEST_VERBOSITY > 1:
 
 
 class TestPostgresqlDatabase(PostgresqlDatabase):
-    insert_returning = True
+    insert_returning = False
 
 
 class DatabaseInitializer(object):

--- a/playhouse/tests/base.py
+++ b/playhouse/tests/base.py
@@ -46,7 +46,7 @@ if TEST_VERBOSITY > 1:
 
 
 class TestPostgresqlDatabase(PostgresqlDatabase):
-    insert_returning = False
+    insert_returning = True
 
 
 class DatabaseInitializer(object):

--- a/playhouse/tests/models.py
+++ b/playhouse/tests/models.py
@@ -109,6 +109,9 @@ class SeqModelB(TestModel):
     id = IntegerField(primary_key=True, sequence='just_testing_seq')
     other_num = IntegerField()
 
+class AutoIncrementModel(TestModel):
+    id = PrimaryKeyField()
+    expected = IntegerField()
 
 class MultiIndexModel(TestModel):
     f1 = CharField()

--- a/playhouse/tests/test_database.py
+++ b/playhouse/tests/test_database.py
@@ -351,12 +351,15 @@ class TestDatabaseSequenceUpdate(ModelTestCase):
     requires = [AutoIncrementModel]
 
     def test_sequence_update(self):
+        orig_insert_returning = AutoIncrementModel._meta.database.insert_returning
+        AutoIncrementModel._meta.database.insert_returning = True
         jump_val = 20
         a = AutoIncrementModel.create(expected=1)
         b =  AutoIncrementModel.create(expected=2)
         c =  AutoIncrementModel.create(id=b.id+jump_val,expected=22)
         AutoIncrementModel.update_auto_pk()
         d =  AutoIncrementModel.create(expected=23)
+        AutoIncrementModel._meta.database.insert_returning = orig_insert_returning
 
         self.assertEqual(a.id, b.id - 1)
         self.assertEqual(b.id, c.id - jump_val)

--- a/playhouse/tests/test_database.py
+++ b/playhouse/tests/test_database.py
@@ -352,7 +352,8 @@ class TestDatabaseSequenceUpdate(ModelTestCase):
 
     def test_sequence_update(self):
         orig_insert_returning = AutoIncrementModel._meta.database.insert_returning
-        AutoIncrementModel._meta.database.insert_returning = True
+        if issubclass(database_class, PostgresqlDatabase):
+            AutoIncrementModel._meta.database.insert_returning = True
         jump_val = 20
         a = AutoIncrementModel.create(expected=1)
         b =  AutoIncrementModel.create(expected=2)

--- a/playhouse/tests/test_database.py
+++ b/playhouse/tests/test_database.py
@@ -348,17 +348,19 @@ class TestConnectionInitialization(PeeweeTestCase):
         self.assertEqual(state['initialized'], 2)
 
 class TestDatabaseSequenceUpdate(ModelTestCase):
-    requires = [DBUser]
+    requires = [AutoIncrementModel]
 
     def test_sequence_update(self):
         jump_val = 20
-        a = DBUser.create(username='a')
-        b =  DBUser.create(username='b')
-        c =  DBUser.create(user_id=b.user_id+jump_val,username='c')
-        DBUser.update_auto_pk()
-        d =  DBUser.create(username='d')
+        a = AutoIncrementModel.create(expected=1)
+        b =  AutoIncrementModel.create(expected=2)
+        c =  AutoIncrementModel.create(id=b.id+jump_val,expected=22)
+        AutoIncrementModel.update_auto_pk()
+        d =  AutoIncrementModel.create(expected=23)
 
-        self.assertEqual(a.user_id, b.user_id - 1)
-        self.assertEqual(b.user_id, c.user_id - jump_val)
-        self.assertEqual(c.user_id, d.user_id - 1)
+        self.assertEqual(a.id, b.id - 1)
+        self.assertEqual(b.id, c.id - jump_val)
+        self.assertEqual(c.id, d.id - 1)
+        for m in [a,b,c,d]:
+            self.assertEqual(m.id, m.expected)
 

--- a/playhouse/tests/test_database.py
+++ b/playhouse/tests/test_database.py
@@ -346,3 +346,19 @@ class TestConnectionInitialization(PeeweeTestCase):
         db.close()
         db.connect()
         self.assertEqual(state['initialized'], 2)
+
+class TestDatabaseSequenceUpdate(ModelTestCase):
+    requires = [DBUser]
+
+    def test_sequence_update(self):
+        jump_val = 20
+        a = DBUser.create(username='a')
+        b =  DBUser.create(username='b')
+        c =  DBUser.create(user_id=b.user_id+jump_val,username='c')
+        DBUser.update_auto_pk()
+        d =  DBUser.create(username='d')
+
+        self.assertEqual(a.user_id, b.user_id - 1)
+        self.assertEqual(b.user_id, c.user_id - jump_val)
+        self.assertEqual(c.user_id, d.user_id - 1)
+


### PR DESCRIPTION
New method to force the DB to ensure that the next auto-generated key will be greater than any existing key, including explicitly inserted keys. On sqlite and MySQL this happens automatically, so the method is a no-op. For Postgresql it provides a canned version of a nice query to update the sequence, saving peewee users from having to write it themselves. 

This might possibly be simplified and better integrated by having a method to turn auto_increment on/off rather than just setting the attribute on the model. Then this method could be run whenever auto_increment is explicitly activated. 