### PR TITLE
Expose parsed db url

### DIFF
--- a/playhouse/tests/test_db_url.py
+++ b/playhouse/tests/test_db_url.py
@@ -1,10 +1,20 @@
 from peewee import *
-from playhouse.db_url import connect
+from playhouse.db_url import connect, parse
 from playhouse.sqlite_ext import SqliteExtDatabase
 from playhouse.tests.base import PeeweeTestCase
 
 
 class TestDBURL(PeeweeTestCase):
+    def test_db_url_parse(self):
+        cfg = parse('mysql://usr:pwd@hst:123/db')
+        self.assertEqual(cfg['user'], 'usr')
+        self.assertEqual(cfg['passwd'], 'pwd')
+        self.assertEqual(cfg['host'], 'hst')
+        self.assertEqual(cfg['database'], 'db')
+        self.assertEqual(cfg['port'], 123)
+        cfg = parse('postgresql://usr:pwd@hst/db')
+        self.assertEqual(cfg['password'], 'pwd')
+
     def test_db_url(self):
         db = connect('sqlite:///:memory:')
         self.assertTrue(isinstance(db, SqliteDatabase))


### PR DESCRIPTION
It'd be useful to get the parsed dict from db_url so it could be used with pooled connections as well.
E.g.:

	db = PooledMySQLDatabase(
	    max_connections=32,
	    stale_timeout=300,  # 5 minutes.
	    **db_url.parse(app.config['DATABASE_URL'])
	    )