### PR TITLE
Support encoding in Postgres

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -3250,13 +3250,15 @@ class PostgresqlDatabase(Database):
 
     register_unicode = True
 
-    def _connect(self, database, **kwargs):
+    def _connect(self, database, encoding=None, **kwargs):
         if not psycopg2:
             raise ImproperlyConfigured('psycopg2 must be installed.')
         conn = psycopg2.connect(database=database, **kwargs)
         if self.register_unicode:
             pg_extensions.register_type(pg_extensions.UNICODE, conn)
             pg_extensions.register_type(pg_extensions.UNICODEARRAY, conn)
+        if encoding:
+            conn.set_client_encoding(encoding)
         return conn
 
     def _get_pk_sequence(self, model):


### PR DESCRIPTION
Hello,

In my case I work with a lot of unicode data. All my databases have a UTF-8 encoding, but I've got errors like this: `UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-5: ordinal not in range(128)`.

I knew about the trick:
```python
database = PosgresqlDatabase(database, **connection_params)
conn = database.get_conn()
conn.set_client_encoding('UTF8')
```

But if you have multiple workers (or pool) it doesn't help and the error still appears. 

So I provide the pull request.
```
database = PostgresqlDatabase(database, encoding='UTF8', **connection_params)
```
Which solve the problem completely.