### PR TITLE
fix when not using named cursor

### DIFF
--- a/playhouse/postgres_ext.py
+++ b/playhouse/postgres_ext.py
@@ -340,7 +340,9 @@ class PostgresqlExtDatabase(PostgresqlDatabase):
         super(PostgresqlExtDatabase, self).__init__(*args, **kwargs)
 
     def get_cursor(self, name=None):
-        return self.get_conn().cursor(name=name)
+        if name:
+            return self.get_conn().cursor(name=name)
+        return self.get_conn().cursor()
 
     def execute_sql(self, sql, params=None, require_commit=True,
                     named_cursor=False):


### PR DESCRIPTION
I'm using peewee on my projects. Thanks. :)

I wrote a simple connection to the postgresql server without named cursor.
```
from peewee import *  # NOQA
from playhouse.postgres_ext import *  # NOQA

database = PostgresqlExtDatabase('test', user='test')


class MyModel(Model):
    name = CharField()
    value = CharField()

    class Meta:
        database = database


MyModel.create_table()
```
An error occurred.
```
Traceback (most recent call last):
  File "test.py", line 15, in <module>
    MyModel.create_table()
  File "/home/vagrant/src/peewee/peewee.py", line 4010, in create_table
    db.create_table(cls)
  File "/home/vagrant/src/peewee/peewee.py", line 3115, in create_table
    return self.execute_sql(*qc.create_table(model_class, safe))
  File "/home/vagrant/src/peewee/playhouse/postgres_ext.py", line 356, in execute_sql
    cursor = self.get_cursor()
  File "/home/vagrant/src/peewee/playhouse/postgres_ext.py", line 343, in get_cursor
    return self.get_conn().cursor(name=name)
TypeError: argument 1 must be string, not None
```