### PR TITLE
Self refrencing joins with aggregate_rows

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -3782,6 +3782,8 @@ class ModelOptions(object):
     def rel_for_model(self, model, field_obj=None):
         is_field = isinstance(field_obj, Field)
         is_node = not is_field and isinstance(field_obj, Node)
+        if isinstance(model, ModelAlias):
+            model = model.model_class
         for field in self.get_fields():
             if isinstance(field, ForeignKeyField) and field.rel_model == model:
                 is_match = any((


### PR DESCRIPTION
Hi again. I was trying to use aggregate_rows to eagerly load a model with a self referencing join, and I found that I could not do so unless the rel_for_model function was altered as per this pull request.

The reason is that rel_for_model doesn't appear to support joins via ModelAlias.