### PR TITLE
Support connect params in db_url

### DIFF
--- a/docs/peewee/playhouse.rst
+++ b/docs/peewee/playhouse.rst
@@ -2998,7 +2998,7 @@ Database URL
 
 This module contains a helper function to generate a database connection from a URL connection string.
 
-.. py:function:: connect(url)
+.. py:function:: connect(url, **connect_params)
 
     Create a :py:class:`Database` instance from the given connection URL.
 

--- a/playhouse/db_url.py
+++ b/playhouse/db_url.py
@@ -52,9 +52,10 @@ def parse(url):
     parsed = urlparse(url)
     return parseresult_to_dict(parsed)
 
-def connect(url):
+def connect(url, **connect_params):
     parsed = urlparse(url)
     connect_kwargs = parseresult_to_dict(parsed)
+    connect_kwargs.update(connect_params)
     database_class = schemes.get(parsed.scheme)
 
     if database_class is None:

--- a/playhouse/tests/test_db_url.py
+++ b/playhouse/tests/test_db_url.py
@@ -20,6 +20,9 @@ class TestDBURL(PeeweeTestCase):
         self.assertTrue(isinstance(db, SqliteDatabase))
         self.assertEqual(db.database, ':memory:')
 
+        db = connect('sqlite:///:memory:', journal_mode='MEMORY')
+        self.assertEqual(db._journal_mode, 'MEMORY')
+
         db = connect('sqliteext:///foo/bar.db')
         self.assertTrue(isinstance(db, SqliteExtDatabase))
         self.assertEqual(db.database, 'foo/bar.db')


### PR DESCRIPTION
Hello!

The PR provides a way to set additional connection params when db_url.connect is used. Such as `encoding` for postgresql and etc.