### PR TITLE
Added small bit in documentation about ForeignKeyField's related_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+build

--- a/docs/peewee/models.rst
+++ b/docs/peewee/models.rst
@@ -217,6 +217,19 @@ Sometimes you only need the associated primary key value from the foreign key co
         # in the column.
         print(tweet.user_id, tweet.message)
 
+:py:class:`ForeignKeyField` allows for a backreferencing property to be bound to the target model. Implicitly, this property will be named `classname_set`, where `classname` is the lowercase name of the class, but can be overriden via the parameter ``related_name``:
+
+.. code-block:: python
+
+    class Message(Model):
+        user = ForeignKeyField(User)
+        text = TextField()
+
+    for message in some_user.message_set:
+        # We are iterating over all Messages whose User is some_user.
+        print message
+
+
 DateTimeField, DateField and TimeField
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/peewee/models.rst
+++ b/docs/peewee/models.rst
@@ -217,16 +217,21 @@ Sometimes you only need the associated primary key value from the foreign key co
         # in the column.
         print(tweet.user_id, tweet.message)
 
-:py:class:`ForeignKeyField` allows for a backreferencing property to be bound to the target model. Implicitly, this property will be named `classname_set`, where `classname` is the lowercase name of the class, but can be overriden via the parameter ``related_name``:
+:py:class:`ForeignKeyField` allows for a backreferencing property to be bound to the target model. Implicitly, this property will be named `classname_set`, where `classname` is the lowercase name of the class, but can be overridden via the parameter ``related_name``:
 
 .. code-block:: python
 
     class Message(Model):
-        user = ForeignKeyField(User)
+        from_user = ForeignKeyField(User)
+        to_user = ForeignKeyField(User, related_name='received_messages')
         text = TextField()
 
     for message in some_user.message_set:
-        # We are iterating over all Messages whose User is some_user.
+        # We are iterating over all Messages whose from_user is some_user.
+        print message
+
+    for message in some_user.received_messages:
+        # We are iterating over all Messages whose to_user is some_user
         print message
 
 


### PR DESCRIPTION
I had a lengthy argument with a co-worker about the implicit `related_name` backreference created by peewee when declaring a `ForeignKeyField`. He was convinced it didn't exist, since it wasn't in the documentation. Only after walking him through the source code and demonstrating it did he believe me. So, for the future, I added a small section in the `ForeignKeyField` docs explaining. 

I do not know how to build/test `peewee`'s documentation but would be glad to if I had some direction. Also accepting changes to what I wrote, if it doesn't match up with the original intent or design.

Also added a `.gitignore` to ignore `.pyc` files and the `build` directory. We can trim that out of here if you feel it doesn't belong, though.