### PR TITLE
Minor docs fix regarding Django middleware

### DIFF
--- a/docs/peewee/database.rst
+++ b/docs/peewee/database.rst
@@ -581,6 +581,7 @@ If you have a django project named *my_blog* and your peewee database is defined
         def process_response(self, request, response):
             if not database.is_closed():
                 database.close()
+            return response
 
 To ensure this middleware gets executed, add it to your ``settings`` module:
 


### PR DESCRIPTION
Django middleware ``process_response`` method must return an ``HttpResponse`` or ``StreamingHttpResponse`` object as its documentation denotes.

https://docs.djangoproject.com/en/1.8/topics/http/middleware/#process-response