### PR TITLE
Add sensible default from Field if Database() wasn't initialized with fields argument

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1428,7 +1428,7 @@ class QueryCompiler(object):
         return '%s%s%s' % (self.quote_char, s, self.quote_char)
 
     def get_column_type(self, f):
-        return self._field_map[f]
+        return self._field_map[f] if f in self._field_map else f.upper()
 
     def get_op(self, q):
         return self._op_map[q]


### PR DESCRIPTION
Modified QueryCompiler.get_column_type to return an uppercase version of the f argument if the field type doesn't exist in _field_map.

This enables a sensible default if a Field subclass defines a type supported by the underlying database that isn't passed into the Database() constructor via its fields initializer.