### PR TITLE
Make array field adapter independent from the connection.

### DIFF
--- a/playhouse/postgres_ext.py
+++ b/playhouse/postgres_ext.py
@@ -107,9 +107,7 @@ class _Array(Node):
         super(_Array, self).__init__()
 
 def adapt_array(arr):
-    conn = arr.field.model_class._meta.database.get_conn()
     items = adapt(arr.items)
-    items.prepare(conn)
     return AsIs('%s::%s%s' % (
         items,
         arr.field.get_column_type(),


### PR DESCRIPTION
Since the field does not depend on the database OIDs, calling `prepare()` is not necessary. This is also mentioned in the docs[1]. The reason this is not dependent on the connection since we don't try to adapt any special OIDs that can vary from one Postgres version to another.

We discovered this when a wrapped connection was used to adapt the new type.
Relevant: opbeat/opbeat_python#68

Thanks in advance for reviewing this.

[1]: http://initd.org/psycopg/docs/extensions.html#psycopg2.extensions.ISQLQuote.prepare