### PR TITLE
adding a .collate_nocase() query feature

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1707,6 +1707,9 @@ class QueryCompiler(object):
         if query._order_by:
             clauses.extend([SQL('ORDER BY'), CommaClause(*query._order_by)])
 
+        if query._collate_nocase:
+            clauses.append(SQL('COLLATE NOCASE'))
+
         if query._limit or (query._offset and db.limit_max):
             limit = query._limit or db.limit_max
             clauses.append(SQL('LIMIT %s' % limit))
@@ -2607,6 +2610,7 @@ class SelectQuery(Query):
         self._having = None
         self._order_by = None
         self._windows = None
+        self._collate_nocase = None
         self._limit = None
         self._offset = None
         self._distinct = False
@@ -2637,6 +2641,7 @@ class SelectQuery(Query):
             query._order_by = list(self._order_by)
         if self._windows is not None:
             query._windows = list(self._windows)
+        query._collate_nocase = self._collate_nocase
         query._limit = self._limit
         query._offset = self._offset
         query._distinct = self._distinct
@@ -2697,6 +2702,10 @@ class SelectQuery(Query):
     @returns_clone
     def window(self, *windows):
         self._windows = list(windows)
+
+    @returns_clone
+    def collate_nocase(self):
+        self._collate_nocase = True
 
     @returns_clone
     def limit(self, lim):


### PR DESCRIPTION
Please let me know if you'd like me to make test and/or documentation changes.

Usage example:

```
order_by(Object.name).collate_nocase()
```