### PR TITLE
Remove extraneous replacement field

### DIFF
--- a/docs/peewee/querying.rst
+++ b/docs/peewee/querying.rst
@@ -369,7 +369,7 @@ You can filter for particular records using normal python operators. Peewee supp
 
     >>> user = User.get(User.username == 'Charlie')
     >>> for tweet in Tweet.select().where(Tweet.user == user, Tweet.is_published == True):
-    ...     print '%s: %s (%s)' % (tweet.user.username, tweet.message)
+    ...     print '%s: %s' % (tweet.user.username, tweet.message)
     ...
     Charlie: hello world
     Charlie: this is fun


### PR DESCRIPTION
There is a mismatch between the number of arguments (two) and the number of fields (three) and the sample output implies that there is an unnecessary replacement field in the format string.