### PR TITLE
Pwiz preservation of composite indices and uniques

### DIFF
--- a/playhouse/tests/test_pwiz.py
+++ b/playhouse/tests/test_pwiz.py
@@ -29,6 +29,10 @@ class Note(BaseModel):
     text = TextField(index=True)
     data = IntegerField(default=0)
     misc = IntegerField(default=0)
+    class Meta:
+        indexes = (
+            (('data', 'misc', 'text'), True),
+        )
 
 class Category(BaseModel):
     name = CharField(unique=True)
@@ -78,6 +82,9 @@ class Note(BaseModel):
 
     class Meta:
         db_table = 'note'
+        indexes = (
+            (('data', 'misc', 'text'), True),
+        )
 """.strip()
 
 
@@ -108,6 +115,9 @@ class Note(BaseModel):
 
     class Meta:
         db_table = 'note'
+        indexes = (
+            (('data', 'misc', 'text'), True),
+        )
 """.strip()
 
 

--- a/pwiz.py
+++ b/pwiz.py
@@ -74,6 +74,9 @@ def print_models(introspector, tables=None, preserve_order=False):
         if not preserve_order:
             columns = sorted(columns)
         primary_keys = database.primary_keys[table]
+        composite_indices = [index_data for index_data in database.indexes[table] if len(index_data.columns) > 1]
+        composite_columns = [col for idx in composite_indices for col in idx.columns]
+
         for name, column in columns:
             skip = all([
                 name in primary_keys,
@@ -86,6 +89,10 @@ def print_models(introspector, tables=None, preserve_order=False):
                 # If we have a CompositeKey, then we do not want to explicitly
                 # mark the columns as being primary keys.
                 column.primary_key = False
+            if column.index and column in composite_columns:
+                # If we have a composite index, then we do not want to explicitly
+                # mark the columns as being index.
+                column.index = False
 
             print_('    %s' % column.get_field())
 
@@ -100,6 +107,13 @@ def print_models(introspector, tables=None, preserve_order=False):
                 if col in primary_keys])
             pk_list = ', '.join("'%s'" % pk for pk in pk_field_names)
             print_('        primary_key = CompositeKey(%s)' % pk_list)
+                        # Add Composite Indices to Meta if they exist
+        if len(composite_indices) > 0:
+            print_('        indexes = (')
+            for composite_index in composite_indices:
+                idx_list = ", ".join("'%s'" % idx for idx in composite_index.columns)
+                print_('            ((%s), %s),' % (idx_list, composite_index.unique))
+            print_('        )')
         print_('')
 
         seen.add(table)


### PR DESCRIPTION
When pwiz creates your model, it will preserve the composite indices and composite unique constraints that you have on your tables in your model.