### PR TITLE
Fix _SortedFieldList, Model._meta.remove_field

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4060,6 +4060,9 @@ class _SortedFieldList(object):
         j = bisect_right(self._keys, k)
         return item in self._items[i:j]
 
+    def index(self, field):
+        return self._keys.index(field._sort_key)
+
     def insert(self, item):
         k = item._sort_key
         i = bisect_left(self._keys, k)
@@ -4067,7 +4070,7 @@ class _SortedFieldList(object):
         self._items.insert(i, item)
 
     def remove(self, item):
-        idx = self._items.index(item)
+        idx = self.index(item)
         del self._items[idx]
         del self._keys[idx]
 
@@ -4158,6 +4161,8 @@ class ModelOptions(object):
         original = self.fields.pop(field_name)
         del self.columns[original.db_column]
         self._sorted_field_list.remove(original)
+        self.sorted_fields = list(self._sorted_field_list)
+        self.sorted_field_names = [f.name for f in self.sorted_fields]
 
         if original.default is not None:
             del self.defaults[original]

--- a/playhouse/tests/test_models.py
+++ b/playhouse/tests/test_models.py
@@ -1005,6 +1005,20 @@ class TestModelAPIs(ModelTestCase):
             [gc.key for gc in last_five],
             ['x-gc5', 'x-gc6', 'x-gc7', 'x-gc8', 'x-gc9'])
 
+    def test_meta_get_field_index(self):
+        index = Blog._meta.get_field_index(Blog.content)
+        self.assertEqual(index, 3)
+
+    def test_meta_remove_field(self):
+
+        class _Model(Model):
+            title = CharField(max_length=25)
+            content = TextField(default='')
+
+        _Model._meta.remove_field('content')
+        self.assertTrue('content' not in _Model._meta.fields)
+        self.assertTrue('content' not in _Model._meta.sorted_field_names)
+
 
 class TestAggregatesWithModels(ModelTestCase):
     requires = [OrderedModel, User, Blog]


### PR DESCRIPTION
Hello, the last release has broken migrations, because ``Model._meta.remove_fields`` actually doesn't work. 

The PR fixes it. I'm waiting for your response and new release.