### PR TITLE
Patch proposal for better database routing - see #701

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2580,7 +2580,8 @@ class Query(Node):
 
     def _execute(self):
         sql, params = self.sql()
-        return self.database.execute_sql(sql, params, self.require_commit)
+        db = self.model_class.determine_database(self, sql, params)
+        return db.execute_sql(sql, params, self.require_commit)
 
     def execute(self):
         raise NotImplementedError
@@ -4399,6 +4400,21 @@ class Model(with_metaclass(BaseModel)):
 
         for k, v in kwargs.items():
             setattr(self, k, v)
+
+    @classmethod
+    def get_read_database(self):
+        return self._meta.database
+
+    @classmethod
+    def get_write_database(self):
+        return self._meta.database
+
+    @classmethod
+    def determine_database(self, query, sql, params):
+        if sql.lower().startswith('select'):
+            return self.get_read_database()
+        else:
+            return self.get_write_database()
 
     @classmethod
     def alias(cls):

--- a/playhouse/read_slave.py
+++ b/playhouse/read_slave.py
@@ -25,22 +25,9 @@ from peewee import *
 
 class ReadSlaveModel(Model):
     @classmethod
-    def _get_read_database(cls):
+    def get_read_database(cls):
         if not getattr(cls._meta, 'read_slaves', None):
             return cls._meta.database
         current_idx = getattr(cls, '_read_slave_idx', -1)
         cls._read_slave_idx = (current_idx + 1) % len(cls._meta.read_slaves)
         return cls._meta.read_slaves[cls._read_slave_idx]
-
-    @classmethod
-    def select(cls, *args, **kwargs):
-        query = super(ReadSlaveModel, cls).select(*args, **kwargs)
-        query.database = cls._get_read_database()
-        return query
-
-    @classmethod
-    def raw(cls, *args, **kwargs):
-        query = super(ReadSlaveModel, cls).raw(*args, **kwargs)
-        if query._sql.lower().startswith('select'):
-            query.database = cls._get_read_database()
-        return query


### PR DESCRIPTION
After several different attempts, this seems to be the cleanest way forward. 

For this patch to be merge worthy, I'd need sign off from @coleifer on these questions about `Using()`. Also feedback from @stas and @alexanderad would be appreciated

This has minimal code impact as `_execute()` seems to handle every edge case, whilst ensuring that queries are still executed in the correct database order (to the extent of all tests passing, there /might/ be untested edge cases).

On the model there is now `determine_database`, by default uses the same SQL string inspection method as `read slave`, but in the event that users are making heavy use of raw queries with `IF()` conditionals, then they can extend to their hearts content.

There is also now `get_read_database()` and `get_write_database()`, by default these continue to use `self._meta.database` but can be modified to whatever the user wants.

The remaining problems now rests with `Using()`, as it does not support two database args. Altering the syntax with extra keywords would make it backwards incompatible, therefore I'd propose that we support the following syntax;

```
Using(database)
Using((read_database, write_database))
```

The last gotcha is whether `Using()` should override model, or visa versa. In my personal opinion, if someone has specified a `Using()` context then this should override whatever is in `get_read_database()` and `get_write_database()`.

From what I can tell, this /should/ cover all use cases from #701.