### PR TITLE
_is_closed check doesn't work with PooledMySQLDatabase and pymysql

### DIFF
--- a/playhouse/pool.py
+++ b/playhouse/pool.py
@@ -165,17 +165,10 @@ class PooledMySQLDatabase(PooledDatabase, MySQLDatabase):
     def _is_closed(self, key, conn):
         is_closed = super(PooledMySQLDatabase, self)._is_closed(key, conn)
         if not is_closed:
-            if hasattr(conn, 'open'):
-                # MySQLdb `ping()` seems to always return `None` in my testing.
-                # So the `open` attribute will be used instead.
-                is_closed = not bool(conn.open)
-            else:
-                # pymysql `ping([reconnect=True])` will indicate if the conn
-                # is closed or not.
-                try:
-                    is_closed = not conn.ping(False)
-                except:
-                    is_closed = True
+            try:
+                conn.ping(False)
+            except:
+                is_closed = True
         return is_closed
 
 class _PooledPostgresqlDatabase(PooledDatabase):


### PR DESCRIPTION
We encountered the same problem as described here: https://github.com/coleifer/peewee/issues/783

Our connections in the pool were closed by MySQL with the 2006 error after reaching server-side timeout. Because we don't always control the environment we run in, we didn't want to guess the my.cnf wait_timeout value and hardcode it in the `stale_timeout` argument for Pool, we just always need to restart a dead connection.

But the solution was simple. The main problem lies [here](https://github.com/coleifer/peewee/blob/7857f08a6fb70fc91c8e884d9eaa2289155d29f5/playhouse/pool.py#L168). This check doesn't work, because `pymysql.connection` also has the `open` attribute (at least in our version 0.6.6). We could use some other method to differentiate between  pymysql and MySQLdb, but there is actually no need. Even though `conn.ping` always [returns None](https://github.com/farcepest/MySQLdb1/blob/d236bb7f6b45f81f0156c4a0cfdef2319ba825d9/_mysql.c#L2011) on MySQLdb, it still does the right thing: throws exception on a dead connection.

After this fix PooledMySQLDatabase recognizes closed connections and everything works good. 