### PR TITLE
PaginatedQuery should not throw 404 on empty query

### DIFF
--- a/playhouse/flask_utils.py
+++ b/playhouse/flask_utils.py
@@ -36,7 +36,10 @@ class PaginatedQuery(object):
         return int(math.ceil(float(self.query.count()) / self.paginate_by))
 
     def get_object_list(self):
-        if self.check_bounds and self.get_page() > self.get_page_count():
+        page_count = self.get_page_count()
+        if page_count == 0:
+            return []
+        elif self.check_bounds and self.get_page() > page_count:
             abort(404)
         return self.query.paginate(self.get_page(), self.paginate_by)
 

--- a/playhouse/tests/test_flask_utils.py
+++ b/playhouse/tests/test_flask_utils.py
@@ -55,6 +55,18 @@ class TestPaginationHelpers(ModelTestCase):
         with self.app.test_request_context('/?p=5'):
             self.assertRaises(Exception, paginated_query.get_object_list)
 
+    def test_empty_query_no_404(self):
+        """Paginated query of no objects should return empty list"""
+        empty_query = User.select().where(
+            (User.username == 'fake-name') &
+            (User.username != 'fake-name')
+        )
+        page_size = 5
+        check_bounds = True
+        paginated_query = PaginatedQuery(empty_query, page_size, check_bounds=check_bounds)
+        with self.app.test_request_context('/'):
+            self.assertEqual(paginated_query.get_object_list(), [])
+
 
 class TestFlaskDB(PeeweeTestCase):
     def tearDown(self):


### PR DESCRIPTION
Working through the [Flask Blog in an hour or less tutorial](https://github.com/econne01/peewee.git), I noticed 404 errors are being thrown when the database is empty.

I think `PaginatedQuery` class should gracefully handle an empty query and return empty set when the query returns no results.