### PR TITLE
Allow to make dynamic related name with current class

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1274,7 +1274,8 @@ class ForeignKeyField(IntegerField):
         return ReverseRelationDescriptor(self)
 
     def _get_related_name(self):
-        return self._related_name or ('%s_set' % self.model_class._meta.name)
+        return (self._related_name or '{classname}_set').format(
+                                        classname=self.model_class._meta.name)
 
     def add_to_class(self, model_class, name):
         if isinstance(self.rel_model, Proxy):

--- a/playhouse/tests/test_models.py
+++ b/playhouse/tests/test_models.py
@@ -377,6 +377,15 @@ class TestModelAPIs(ModelTestCase):
 
         self.assertRaises(AttributeError, make_klass)
 
+    def test_dynamic_related_name(self):
+        class Foo(TestModel):
+            f1 = CharField()
+
+        class FooRel(TestModel):
+            foo = ForeignKeyField(Foo, related_name='{classname}_bar')
+
+        self.assertTrue(hasattr(Foo, 'foorel_bar'))
+
     def test_fk_exceptions(self):
         c1 = Category.create(name='c1')
         c2 = Category.create(parent=c1, name='c2')


### PR DESCRIPTION
When declaring a ForeignKey in an abstract class, this allows
to customize the related_name for each child.

For example:
```python
class Other:
    pass

class Abstract:
    # Will create Other.child1_foo and Other.child2_foo accessors.
    other = ForeignKey(Other, related_name='{classname}_foo')

class Child1(Abstract):
    pass

class Child2(Abstract):
    pass
```

Thanks :)