### PR TITLE
Proposed fix for #845

### DIFF
--- a/playhouse/apsw_ext.py
+++ b/playhouse/apsw_ext.py
@@ -60,6 +60,11 @@ class APSWDatabase(SqliteExtDatabase):
 
     def _connect(self, database, **kwargs):
         conn = apsw.Connection(database, **kwargs)
+        try:
+            self._add_conn_hooks(conn)
+        except:
+            conn.close()
+            raise
         if self.timeout is not None:
             conn.setbusytimeout(self.timeout)
         conn.createscalarfunction('date_part', _sqlite_date_part, 2)

--- a/playhouse/tests/test_apsw.py
+++ b/playhouse/tests/test_apsw.py
@@ -3,6 +3,7 @@ import datetime
 
 from playhouse.apsw_ext import *
 from playhouse.tests.base import ModelTestCase
+from playhouse.tests.base import PragmaTestCase
 
 
 db = APSWDatabase(':memory:')
@@ -97,3 +98,10 @@ class APSWTestCase(ModelTestCase):
         create_success()
         self.assertEqual(User.select().count(), 2)
         self.assertEqual(Message.select().count(), 2)
+
+
+class APSWPragmaTestCase(PragmaTestCase):
+    db_class = APSWDatabase
+
+    def test_pragmas(self):
+        self._test_pragmas()

--- a/playhouse/tests/test_database.py
+++ b/playhouse/tests/test_database.py
@@ -14,6 +14,7 @@ from playhouse.tests.base import database_class
 from playhouse.tests.base import database_initializer
 from playhouse.tests.base import ModelTestCase
 from playhouse.tests.base import PeeweeTestCase
+from playhouse.tests.base import PragmaTestCase
 from playhouse.tests.base import query_db
 from playhouse.tests.base import skip_unless
 from playhouse.tests.base import test_db
@@ -347,3 +348,10 @@ class TestConnectionInitialization(PeeweeTestCase):
         db.close()
         db.connect()
         self.assertEqual(state['initialized'], 2)
+
+
+class TestPragmaInitialization(PragmaTestCase):
+    db_class = SqliteDatabase
+
+    def test_pragmas(self):
+        self._test_pragmas()

--- a/playhouse/tests/test_sqlite_ext.py
+++ b/playhouse/tests/test_sqlite_ext.py
@@ -11,6 +11,7 @@ from playhouse.sqlite_ext import *
 from playhouse.tests.base import database_initializer
 from playhouse.tests.base import ModelTestCase
 from playhouse.tests.base import PeeweeTestCase
+from playhouse.tests.base import PragmaTestCase
 from playhouse.tests.base import skip_if
 from playhouse.tests.base import skip_unless
 
@@ -1180,3 +1181,10 @@ class TestTransitiveClosureIntegration(PeeweeTestCase):
             ('westerns', 3),
             ('hard scifi', 4),
         ])
+
+
+class SqliteExtPragmaTestCase(PragmaTestCase):
+    db_class = SqliteExtDatabase
+
+    def test_pragmas(self):
+        self._test_pragmas()


### PR DESCRIPTION
APSWDatabase _connect() without also making a call to _add_conn_hooks().

This was resulting in the pragmas keyword for __init__ being ignored as the call to _set_pragmas  was never made.

I've added test cases that illustrate my original problem and added the call to _add_conn_hooks() to APSWDatabase._connect().