### PR TITLE
Get extra connection args from query string in db_url

### DIFF
--- a/docs/peewee/playhouse.rst
+++ b/docs/peewee/playhouse.rst
@@ -3703,6 +3703,7 @@ This module contains a helper function to generate a database connection from a 
     * *sqlite:///:memory:* will create an in-memory :py:class:`SqliteDatabase` instance.
     * *postgresql://postgres:my_password@localhost:5432/my_database* will create a :py:class:`PostgresqlDatabase` instance. A username and password are provided, as well as the host and port to connect to.
     * *mysql://user:passwd@ip:port/my_db* will create a :py:class:`MySQLDatabase` instance for the local MySQL database *my_db*.
+    * *mysql+pool://user:passwd@ip:port/my_db?max_connections=20&stale_timeout=300* will create a :py:class:`PooledMySQLDatabase` instance for the local MySQL database *my_db* with max_connections set to 20 and a stale_timeout setting of 300 seconds.
 
     Supported schemes:
 
@@ -3729,7 +3730,7 @@ This module contains a helper function to generate a database connection from a 
 
 .. py:function:: parse(url)
 
-    Parse the information in the given URL into a dictionary containing ``database``, ``host``, ``port``, ``user`` and/or ``password``.
+    Parse the information in the given URL into a dictionary containing ``database``, ``host``, ``port``, ``user`` and/or ``password``. Additional connection arguments can be passed in the URL query string.
 
     If you are using a custom database class, you can use the ``parse()`` function to extract information from a URL which can then be passed in to your database object.
 

--- a/playhouse/tests/test_db_url.py
+++ b/playhouse/tests/test_db_url.py
@@ -14,6 +14,15 @@ class TestDBURL(PeeweeTestCase):
         self.assertEqual(cfg['port'], 123)
         cfg = parse('postgresql://usr:pwd@hst/db')
         self.assertEqual(cfg['password'], 'pwd')
+        cfg = parse('mysql+pool://usr:pwd@hst:123/db'
+                    '?max_connections=42&stale_timeout=8001')
+        self.assertEqual(cfg['user'], 'usr')
+        self.assertEqual(cfg['password'], 'pwd')
+        self.assertEqual(cfg['host'], 'hst')
+        self.assertEqual(cfg['database'], 'db')
+        self.assertEqual(cfg['port'], 123)
+        self.assertEqual(cfg['max_connections'], '42')
+        self.assertEqual(cfg['stale_timeout'], '8001')
 
     def test_db_url(self):
         db = connect('sqlite:///:memory:')


### PR DESCRIPTION
### Changes
- As discussed in #858, this adds support for supplying extra connection args in the query string when using playhouse.db_url