### PR TITLE
Added SmallIntegerField to __all__

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -81,6 +81,7 @@ __all__ = [
     'ProgrammingError',
     'Proxy',
     'R',
+    'SmallIntegerField',
     'SqliteDatabase',
     'SQL',
     'TextField',


### PR DESCRIPTION
`SmallIntegerField` wasn't listed in the peewee module `__all__` list. 