### PR TITLE
Fix logic error

### DIFF
--- a/playhouse/shortcuts.py
+++ b/playhouse/shortcuts.py
@@ -133,7 +133,7 @@ def model_to_dict(model, recurse=True, backrefs=False, only=None,
             descriptor = getattr(model_class, related_name)
             if descriptor in exclude or foreign_key in exclude:
                 continue
-            if only and (descriptor not in only or foreign_key not in only):
+            if only and descriptor not in only and foreign_key not in only:
                 continue
 
             accum = []


### PR DESCRIPTION
## Fixed
* fix logic error in `playhouse.shortcuts.model_to_dict`
    if `backrefs = True`,  only `descriptor` and `foreign_key` fields both not in the `only` will excute `continue`

```
class User(Model):
    name = CharField()

class Tweet(Model):
    use = ForeignKeyField(User, related_name='tweets')

user = User(name='tim')
tweet = Tweet(user=user, content='my first tweets')
```

I  define two model  `User` and `Tweet`, and when I use `model_to_dict`, the output is

```
d = model_to_dict(user, only=[User.name, User.tweets, Tweet.content], backrefs=True)
print(d)
>>> {'name': 'tim'}
```
but the expect results should be
```
>>> {'name': 'tim', 'tweets': {'content': 'my first tweets'}}
```
This PR fixed this issue