### PR TITLE
Removed side effects while cleaning prefetch query

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4802,6 +4802,7 @@ class Model(with_metaclass(BaseModel)):
         return not self == other
 
 def clean_prefetch_subquery(query):
+    query = query.clone()
     query._group_by = query._having = None
     return query
 

--- a/playhouse/tests/test_query_results.py
+++ b/playhouse/tests/test_query_results.py
@@ -1103,6 +1103,19 @@ class TestPrefetch(BaseTestPrefetch):
                 ('u4', 'b6'),
             ])
 
+    def test_prefetch_group_by(self):
+        users = (User
+                 .select(User, fn.Max(fn.Length(Blog.content)).alias('max_content_len'))
+                 .join(Blog, JOIN_LEFT_OUTER)
+                 .group_by(User)
+                 .order_by(User.id))
+        blogs = Blog.select()
+        comments = Comment.select()
+        with self.assertQueryCount(3):
+            result = prefetch(users, blogs, comments)
+            self.assertEqual(len(result), 4)
+            
+
     def test_prefetch_self_join(self):
         self._build_category_tree()
         Child = Category.alias()


### PR DESCRIPTION
There was a strange behaviour: then you do prefetch on complex query with some grouping, you will have some kind of exception or incorrect result. The reason of this is simple: `clean_prefetch_query` removes any information about grouping from query before placing it as subquery in prefetch queries, but it is done on original query instead of cloned one. 

This pr fixes this little bug(in a single code line ^_^).