### PR TITLE
doc shows wrong default value for wrapped_count parameter

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -1268,7 +1268,7 @@ Query Types
         >>> deleted_tweets.count()
         3  # number of tweets that are marked as deleted
 
-    .. py:method:: wrapped_count([clear_limit=True])
+    .. py:method:: wrapped_count([clear_limit=False])
 
         :param bool clear_limit: Remove any limit or offset clauses from the query before counting.
         :rtype: an integer representing the number of rows in the current query


### PR DESCRIPTION
`wrapped_count` has default value `False` for `clear_limit`, but the doc shows `True`