### PR TITLE
Change description of options in Using class docs

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -2470,7 +2470,7 @@ The easiest way to create transactions and savepoints is to use :py:meth:`Databa
 
 .. py:class:: Using(database, models[, with_transaction=True])
 
-    For the duration of the wrapped block, all queries against the given ``models`` will use the specified ``database``. Optionally these queries can be run inside a transaction by specifying ``with_transaction=True``.
+    For the duration of the wrapped block, all queries against the given ``models`` will use the specified ``database``. Optionally these queries can be run outside a transaction by specifying ``with_transaction=False``.
 
     ``Using`` provides, in short, a way to run queries on a list of models using a manually specified database.
 


### PR DESCRIPTION
Previous description implied that the default for the "with_transaction" kwarg was False, while the default is True. Developers must specify "with_transaction=False" if they don't want to use a transaction block with the Using class context.