### PR TITLE
Add configuration check for sqlite

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -3651,6 +3651,8 @@ class SqliteDatabase(Database):
         super(SqliteDatabase, self).__init__(database, *args, **kwargs)
 
     def _connect(self, database, **kwargs):
+        if not sqlite3:
+            raise ImproperlyConfigured('pysqlite or sqlite3 must be installed.')
         conn = sqlite3.connect(database, **kwargs)
         conn.isolation_level = None
         try:


### PR DESCRIPTION
Some operating systems don't have sqlite3 module within python3.
without this commit, they will get unclear error message like this:

```
File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3371, in
connect
    **self.connect_kwargs)
  File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3609, in
_connect
    conn = sqlite3.connect(database, **kwargs)
AttributeError: 'NoneType' object has no attribute 'connect'
```

Those users who encounter this ImproperlyConfiguredError
may have to install sqlite dependencies and recompile their python3