### PR TITLE
fix:playhouse connect database_url error

### DIFF
--- a/playhouse/pool.py
+++ b/playhouse/pool.py
@@ -72,8 +72,8 @@ logger = logging.getLogger('peewee.pool')
 class PooledDatabase(object):
     def __init__(self, database, max_connections=20, stale_timeout=None,
                  **kwargs):
-        self.max_connections = max_connections
-        self.stale_timeout = stale_timeout
+        self.max_connections = int(max_connections)
+        self.stale_timeout = float(stale_timeout)
         self._connections = []
         self._in_use = {}
         self._closed = set()


### PR DESCRIPTION
fix:playhouse connect database_url, the max_connections is mistaken for the type of 'str', so the error occur at https://github.com/coleifer/peewee/blob/master/playhouse/pool.py#L126

example:
```
BACKEND_MYSQL="mysql+pool://root:root@127.0.0.1/torweb?max_connections=20&stale_timeout=300"
```
`max_connections` and `stale_timeout` are mistaken for the type of 'str', and error occur

```
Traceback (most recent call last):
  File "/Users/jmpews/virtualenv/torweb/lib/python3.5/site-packages/tornado/web.py", line 1422, in _execute
    result = self.prepare()
  File "/Users/jmpews/Desktop/codesnippet/python/torweb/handlers/basehandlers/basehandler.py", line 18, in prepare
    db_mysql.connect()
  File "/Users/jmpews/virtualenv/torweb/lib/python3.5/site-packages/peewee.py", line 3402, in connect
    **self.connect_kwargs)
  File "/Users/jmpews/virtualenv/torweb/lib/python3.5/site-packages/playhouse/pool.py", line 126, in _connect
    len(self._in_use) >= self.max_connections):
TypeError: unorderable types: int() >= str()
```

and
perhaps there are still other types of errors