### PR TITLE
workaround for issue 820 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,25 @@ readme = f.read()
 f.close()
 
 setup_kwargs = {}
-cython_installed = True
+cython_min_version = '0.22.1'
 try:
     from Cython.Distutils import build_ext
     from Cython import __version__ as cython_version
-    if StrictVersion(cython_version) < StrictVersion('0.22.1'):
-        cython_installed = False
-        warnings.warn('Your Cython appears to be an older version. You may '
-                      'need to upgrade Cython in order to build the peewee '
-                      'C extensions. For now, Cython support is disabled.')
 except ImportError:
     cython_installed = False
+    warnings.warn('Cython C extensions for peewee will NOT be built, because '
+                  'Cython does not seem to be installed. To enable Cython C '
+                  'extensions, install Cython >=' + cython_min_version + '.')
+else:
+    if StrictVersion(cython_version) < StrictVersion(cython_min_version):
+        cython_installed = False
+        warnings.warn('Cython C extensions for peewee will NOT be built, '
+                      'because the installed Cython version '
+                      '(' + cython_version + ') is too old. To enable Cython '
+                      'C extensions, install Cython >=' + cython_min_version +
+                      '.')
+    else:
+        cython_installed = True
 
 speedups_ext_module = Extension(
     'playhouse._speedups',

--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,17 @@ readme = f.read()
 f.close()
 
 setup_kwargs = {}
+cython_installed = True
 try:
     from Cython.Distutils import build_ext
     from Cython import __version__ as cython_version
     if StrictVersion(cython_version) < StrictVersion('0.22.1'):
+        cython_installed = False
         warnings.warn('Your Cython appears to be an older version. You may '
                       'need to upgrade Cython in order to build the peewee '
-                      'C extensions.')
+                      'C extensions. For now, Cython support is disabled.')
 except ImportError:
     cython_installed = False
-else:
-    cython_installed = True
 
 speedups_ext_module = Extension(
     'playhouse._speedups',


### PR DESCRIPTION
For me, issue #820 wasn't really solved yet - I run Debian 8 (stable) on several machines, and it comes with Cython 0.21.1. Because I want to keep program versions on my machines in sync, I tend to not install newer versions manually. This commit proposes a workaround for issue #820 which disables Cython support for Cython versions below 0.22.1.