### PR TITLE
make genned table aliases more human-friendly

### DIFF
--- a/playhouse/tests/README
+++ b/playhouse/tests/README
@@ -1,3 +1,10 @@
+Setup:
+
+Make sure you create your postgres database w/ the `postgres` user, otherwise 
+you get permission errors as the tests are run as `postgres`:
+
+    $ createdb -U postgres peewee_test
+
 Run peewee tests:
 
     $ python runtests.py (-e sqlite, -e postgres, -e mysql)

--- a/playhouse/tests/test_models.py
+++ b/playhouse/tests/test_models.py
@@ -1190,7 +1190,7 @@ class TestMultiTableFromClause(ModelTestCase):
         sql, params = compiler.generate_select(outer)
         self.assertEqual(sql, (
             'SELECT "users"."username" FROM '
-            '(SELECT "users"."username" FROM "users" AS users) AS t1'))
+            '(SELECT "users"."username" FROM "users" AS users) AS u1'))
 
         self.assertEqual(
             [u.username for u in outer.order_by(User.username)], ['u0', 'u1'])
@@ -1203,7 +1203,7 @@ class TestMultiTableFromClause(ModelTestCase):
         sql, params = compiler.generate_select(outer)
         self.assertEqual(sql, (
             'SELECT "t1"."name" FROM '
-            '(SELECT "users"."username" AS name FROM "users" AS users) AS t1'))
+            '(SELECT "users"."username" AS name FROM "users" AS users) AS u1'))
 
         query = outer.order_by(inner.c.name.desc())
         self.assertEqual([u[0] for u in query.tuples()], ['u1', 'u0'])


### PR DESCRIPTION
instead of: `select t1.id from ledger_entry as t1`
generate the alias from the table name: `select le1.id from ledger_entry as le1`

where the alias is an acronym of the table name.  makes it easier to read large joins w/ many tables.

@coleifer unit tests not updated yet.  i want to know if you're ok-with/opposed to this before i spend the time on that part.