### PR TITLE
Infer alias when only one interpretation

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1772,7 +1772,7 @@ class QueryCompiler(object):
             if query._from is None:
                 clauses.append(model.as_entity().alias(alias_map[model]))
             else:
-                [alias_map[x] for x in query._from] # seed the alias map
+                [alias_map[x] for x in query._from if not isinstance(x, Clause)] # seed the alias map
                 clauses.append(CommaClause(*query._from))
 
         if query._windows is not None:

--- a/peewee.py
+++ b/peewee.py
@@ -1416,9 +1416,15 @@ class AliasMap(object):
             self.add(obj)
         return self._alias_map[obj]
 
-    def lookup(self, obj):
+    def lookup(self, obj, loose=True):
         if obj in self._alias_map:
             return self._alias_map[obj]
+        if loose and issubclass(obj, Model):
+          possible_aliases = [x for x in self._alias_map.keys() if isinstance(x,ModelAlias) and x.model_class==obj]
+          if len(possible_aliases) == 1:
+            return self._alias_map[possible_aliases[0]]
+          if len(possible_aliases) > 1:
+            raise ProgrammingError('more than one %s is part of this query - please use an alias to avoid ambiguity' % obj)
         raise ProgrammingError('%s is not a part of this query' % obj)
 
     def __contains__(self, obj):

--- a/peewee.py
+++ b/peewee.py
@@ -1416,6 +1416,11 @@ class AliasMap(object):
             self.add(obj)
         return self._alias_map[obj]
 
+    def lookup(self, obj):
+        if obj in self._alias_map:
+            return self._alias_map[obj]
+        raise ProgrammingError('%s is not a part of this query' % obj)
+
     def __contains__(self, obj):
         return obj in self._alias_map
 
@@ -1566,7 +1571,7 @@ class QueryCompiler(object):
     def _parse_field(self, node, alias_map, conv):
         if alias_map:
             sql = '.'.join((
-                self.quote(alias_map[node.model_class]),
+                self.quote(alias_map.lookup(node.model_class)),
                 self.quote(node.db_column)))
         else:
             sql = self.quote(node.db_column)
@@ -1767,6 +1772,7 @@ class QueryCompiler(object):
             if query._from is None:
                 clauses.append(model.as_entity().alias(alias_map[model]))
             else:
+                [alias_map[x] for x in query._from] # seed the alias map
                 clauses.append(CommaClause(*query._from))
 
         if query._windows is not None:

--- a/playhouse/tests/test_compound_queries.py
+++ b/playhouse/tests/test_compound_queries.py
@@ -138,7 +138,7 @@ class TestCompoundSelectSQL(PeeweeTestCase):
             'UNION '
             'SELECT "t2"."beta" FROM "beta" AS t2 WHERE ("t2"."beta" < ?) '
             'UNION '
-            'SELECT "t3"."beta" FROM "beta" AS t3 WHERE ("t3"."beta" > ?)'
+            'SELECT "t4"."beta" FROM "beta" AS t4 WHERE ("t4"."beta" > ?)'
             ') AS cq'))
         self.assertEqual(params, [2, 3, 4])
 

--- a/playhouse/tests/test_postgres.py
+++ b/playhouse/tests/test_postgres.py
@@ -17,7 +17,7 @@ from playhouse.tests.base import database_initializer
 from playhouse.tests.base import ModelTestCase
 from playhouse.tests.base import PeeweeTestCase
 from playhouse.tests.base import skip_if
-from playhouse.tests.models import TestingID
+from playhouse.tests.models import TestingID as _TestingID
 
 
 class TestPostgresqlExtDatabase(PostgresqlExtDatabase):
@@ -103,6 +103,10 @@ class Post(BaseModel):
     user = ForeignKeyField(User)
     content = TextField()
     timestamp = DateTimeField(default=datetime.datetime.now)
+
+class TestingID(_TestingID):
+    class Meta:
+        database = test_db
 
 MODELS = [
     Testing,

--- a/playhouse/tests/test_queries.py
+++ b/playhouse/tests/test_queries.py
@@ -765,6 +765,19 @@ class TestSelectQuery(PeeweeTestCase):
             'WHERE (("t1"."username" = ?) AND ("t2"."id" = ?))'))
         self.assertEqual(params, ['charlie', 2])
 
+    def test_select_from_implied_alias(self):
+        query = User.alias().select().where(User.username=='charlie')
+        sql, params = normal_compiler.generate_select(query)
+        self.assertEqual(sql, (
+            'SELECT "t1"."id", "t1"."username" '
+            'FROM "users" AS t1 '
+            'WHERE ("t1"."username" = ?)'))
+        self.assertEqual(params, ['charlie'])
+
+    def test_select_from_ambiguous_implied_alias(self):
+        query = User.alias().select().join(User.alias(), on=User.username=='charlie')
+        self.assertRaises(ProgrammingError, lambda: normal_compiler.generate_select(query))
+
 class TestUpdateQuery(PeeweeTestCase):
     def setUp(self):
         super(TestUpdateQuery, self).setUp()

--- a/playhouse/tests/test_queries.py
+++ b/playhouse/tests/test_queries.py
@@ -321,6 +321,13 @@ class TestSelectQuery(PeeweeTestCase):
             'INNER JOIN "blog" AS blog ON '
             '"blog"."user_id"'])
 
+    def test_aliasing_in_select(self):
+        sq = User.select(User.id, Blog.select(fn.GROUP_CONCAT(' ', Blog.title)).where(Blog.user == User.id))
+        sql = compiler.generate_select(sq)
+        self.assertEqual(sql, (
+            'SELECT "users"."id", (SELECT GROUP_CONCAT(?, "blog"."title") FROM "blog" AS blog WHERE ("blog"."user_id" = "users"."id")) FROM "users" AS users',
+            [' ']))
+
     def test_where(self):
         sq = SelectQuery(User).where(User.id < 5)
         self.assertWhere(sq, '("users"."id" < ?)', [5])


### PR DESCRIPTION
likewise for the alias matching version of that same basic code change for https://github.com/coleifer/peewee/issues/965

not that this is now valid:

```python
User.alias().select().where(User.username=='charlie')
```

but this is still not:
```python
User.alias().select().join(User.alias(), on=User.username=='charlie')
```
