### PR TITLE
Test case for RowID + insert_many bug

### DIFF
--- a/playhouse/tests/test_sqlite_ext.py
+++ b/playhouse/tests/test_sqlite_ext.py
@@ -806,6 +806,17 @@ class TestRowIDField(ModelTestCase):
         self.assertEqual(r_db2.rowid, 2)
         self.assertEqual(r_db2.data, 20)
 
+    def test_insert_with_rowid(self):
+        RowIDModel.insert({RowIDModel.rowid: 5, 'data': 1}).execute()
+        self.assertEqual(5, RowIDModel.select(RowIDModel.rowid).first().rowid)
+
+    def test_insert_many_with_rowid_without_field_validation(self):
+        RowIDModel.insert_many([{RowIDModel.rowid: 5, 'data': 1}], validate_fields=False).execute()
+        self.assertEqual(5, RowIDModel.select(RowIDModel.rowid).first().rowid)
+
+    def test_insert_many_with_rowid_with_field_validation(self):
+        RowIDModel.insert_many([{RowIDModel.rowid: 5, 'data': 1}], validate_fields=True).execute()
+        self.assertEqual(5, RowIDModel.select(RowIDModel.rowid).first().rowid)
 
 class TestTransitiveClosure(PeeweeTestCase):
     def test_model_factory(self):


### PR DESCRIPTION
This is the problem I mentioned in #971. Not sure how to fix this properly, for now just added a bunch of tests to document the problem. The first two tests pass, only the last one fails.

```
Traceback (most recent call last):
  File "/Users/jan/projects/peewee/playhouse/tests/test_sqlite_ext.py", line 818, in test_insert_many_with_rowid_with_field_validation
    RowIDModel.insert_many([{RowIDModel.rowid: 5, 'data': 1}], validate_fields=True).execute()
  File "/Users/jan/projects/peewee/peewee.py", line 3351, in execute
    cursor = self._execute()
  File "/Users/jan/projects/peewee/peewee.py", line 2747, in _execute
    sql, params = self.sql()
  File "/Users/jan/projects/peewee/peewee.py", line 3319, in sql
    return self.compiler().generate_insert(self)
  File "/Users/jan/projects/peewee/peewee.py", line 1960, in generate_insert
    for row_dict in query._iter_rows():
  File "/Users/jan/projects/peewee/peewee.py", line 3271, in _iter_rows
    validate_field(key)
  File "/Users/jan/projects/peewee/peewee.py", line 3261, in validate_field
    raise KeyError('"%s" is not a recognized field.' % field)
KeyError: '"<playhouse.sqlite_ext.RowIDField object at 0x102dc81d0>" is not a recognized field.'
```