### PR TITLE
Prevent the silent overwriting of model's attributes e.g. "foo_id" when "foo" foreign key added

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1400,6 +1400,15 @@ class ForeignKeyField(IntegerField):
                 raise AttributeError(error % (
                     self.model_class._meta.name, self.name, self.related_name))
 
+        if hasattr(model_class, name + '_id'):
+            name_id_attr = getattr(model_class, name + '_id')
+            if not (isinstance(name_id_attr, ForeignKeyField) and
+                    (name_id_attr.db_column == self.db_column)):
+                error = ('Foreign key: %s.%s id descriptor "%s" collision with'
+                         ' model attribute of the same name.')
+                raise AttributeError(error % (
+                    self.model_class._meta.name, self.name, name + '_id'))
+
         setattr(model_class, name, self._get_descriptor())
         setattr(model_class, name + '_id', self._get_id_descriptor())
         setattr(self.rel_model,

--- a/playhouse/tests/test_models.py
+++ b/playhouse/tests/test_models.py
@@ -391,6 +391,19 @@ class TestModelAPIs(ModelTestCase):
 
         self.assertRaises(AttributeError, make_klass)
 
+    def test_id_descriptor_collision(self):
+        class Bar(TestModel):
+            name = CharField()
+
+        class Foo(TestModel):
+            foobarbaz = ForeignKeyField(Bar)
+
+        def make_class():
+            class ExtFoo(Foo):
+                foobarbaz_id = CharField()
+
+        self.assertRaises(AttributeError, make_class)
+
     def test_callable_related_name(self):
         class Foo(TestModel):
             pass


### PR DESCRIPTION
In complex structures with a large number of fields easy to miss the collision, especially if it happened with parrent's model attribute.
Considering that the python dict doesn't guarantee the order of items, there are two possibilities:
1. The *_id attr will be overwritten by ObjectIdDescriptor and will no longer available, but field (if the attr is a field) still will be in _meta.fields. This leads to unexpected and floating bugs.
2. ObjectIdDescriptor will be overwritten by custom attribute. Much less harmful and may be unnoticed for a long time.

I think it should explicitly show the possible issue, by throwing an exception.