### PR TITLE
Add mention in the doc about calling order_by() without argument to remove the ORDER BY clause.

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -1063,6 +1063,12 @@ Query Types
                 .group_by(User)
                 .order_by(tweet_ct.desc(), User.username))
 
+        Call it without argument to remove any previously added order by clause;
+
+        .. code-block:: python
+
+            User.select().order_by().first()
+
     .. py:method:: window(*windows)
 
         :param Window windows: One or more :py:class:`Window` instances.


### PR DESCRIPTION
Note: my first attempt was to call `order_by(None)`. Would you mind a PR to allow also this signature?