### PR TITLE
Fix truncate_date for PostgreSQL

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -3753,7 +3753,7 @@ class Database(object):
         return fn.EXTRACT(Clause(date_part, R('FROM'), date_field))
 
     def truncate_date(self, date_part, date_field):
-        return fn.DATE_TRUNC(SQL(date_part), date_field)
+        return fn.DATE_TRUNC(date_part, date_field)
 
     def default_insert_clause(self, model_class):
         return SQL('DEFAULT VALUES')


### PR DESCRIPTION
The following script doesn't work:

```python
#!/usr/bin/env python
import peewee, datetime

database = peewee.PostgresqlDatabase('mmwatch', host='localhost')

class Number(peewee.Model):
    date = peewee.DateTimeField(default=datetime.datetime.now)

    class Meta:
        database = database

database.connect()
database.create_tables([Number], safe=True)
number = Number()
number.save()
q = Number.select(database.truncate_date('day', Number.date))
for row in q:
    print row.date
```

It fails with the following error:

```
Traceback (most recent call last):
  File "./date_trunc_pgsql_fail.py", line 19, in <module>
    for row in q:
  File "/Users/ilyazverev/Progr/git/mmwatch/mmwatch/venv/lib/python2.7/site-packages/peewee.py", line 2967, in __iter__
    return iter(self.execute())
  File "/Users/ilyazverev/Progr/git/mmwatch/mmwatch/venv/lib/python2.7/site-packages/peewee.py", line 2960, in execute
    self._qr = ResultWrapper(model_class, self._execute(), query_meta)
  File "/Users/ilyazverev/Progr/git/mmwatch/mmwatch/venv/lib/python2.7/site-packages/peewee.py", line 2656, in _execute
    return self.database.execute_sql(sql, params, self.require_commit)
  File "/Users/ilyazverev/Progr/git/mmwatch/mmwatch/venv/lib/python2.7/site-packages/peewee.py", line 3492, in execute_sql
    self.commit()
  File "/Users/ilyazverev/Progr/git/mmwatch/mmwatch/venv/lib/python2.7/site-packages/peewee.py", line 3316, in __exit__
    reraise(new_type, new_type(*exc_args), traceback)
  File "/Users/ilyazverev/Progr/git/mmwatch/mmwatch/venv/lib/python2.7/site-packages/peewee.py", line 3485, in execute_sql
    cursor.execute(sql, params or ())
peewee.ProgrammingError: column "day" does not exist
LINE 1: SELECT DATE_TRUNC(day, "t1"."date") FROM "number" AS t1
                          ^
```

The reason is that `'day'` is passed to the query builder as-is, not escaped as a string. This pull request fixes that.