### PR TITLE
Accept DATABASE_URL config variable in flask_utils

### DIFF
--- a/playhouse/flask_utils.py
+++ b/playhouse/flask_utils.py
@@ -87,7 +87,8 @@ class FlaskDB(object):
         self._app = app
 
         if self._db is None:
-            initial_db = app.config['DATABASE']
+            initial_db = (app.config.get('DATABASE_URL') or
+                          app.config['DATABASE'])
         else:
             initial_db = self._db
 


### PR DESCRIPTION
Makes working with Heroku's `DATABASE_URL` standard slightly more straightforward, since Flask Utils already works with a connection URL out-of-the-box.
