### PR TITLE
The update of BooleanField coerce

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1265,16 +1265,17 @@ class TimestampField(IntegerField):
 
 class BooleanField(Field):
     db_field = 'bool'
+    
     def coerce(self, value):
-    if value == 'true':
-        return True
-    elif value == 'false':
-        return False
-    else:
-        try:
-            return bool(int(value))
-        except:
-            return bool(value)
+        if value == 'true':
+            return True
+        elif value == 'false':
+            return False
+        else:
+            try:
+                return bool(int(value))
+            except:
+                return bool(value)
 
 class RelationDescriptor(FieldDescriptor):
     """Foreign-key abstraction to replace a related PK with a related model."""

--- a/peewee.py
+++ b/peewee.py
@@ -1265,7 +1265,16 @@ class TimestampField(IntegerField):
 
 class BooleanField(Field):
     db_field = 'bool'
-    coerce = bool
+    def coerce(self, value):
+    if value == 'true':
+        return True
+    elif value == 'false':
+        return False
+    else:
+        try:
+            return bool(int(value))
+        except:
+            return bool(value)
 
 class RelationDescriptor(FieldDescriptor):
     """Foreign-key abstraction to replace a related PK with a related model."""


### PR DESCRIPTION
Good afternoon, coleifer. We've found the most common case is that the data from the client(as browser) will send true or false, 1 or 0 to the server, but the conversion should be decided by peewee on the data field type. So may be the update of mine makes common sense.