### PR TITLE
SqliteMigrator: fix edge case in rename_column

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -650,7 +650,11 @@ class SqliteMigrator(SchemaMigrator):
             if column_to_update in index.columns:
                 if new_column:
                     queries.append(
-                        SQL(index.sql.replace(column_to_update, new_column)))
+                        SQL(index.sql
+                            .replace('("' + column_to_update + '"', '("' + new_column + '"')
+                            .replace('"' + column_to_update + '")', '"' + new_column + '")')
+                            .replace('_' + column_to_update + '"', '_' + new_column + '"')
+                            .replace('_' + column_to_update + '_', '_' + new_column + '_')))
             else:
                 queries.append(SQL(index.sql))
 

--- a/playhouse/tests/test_migrate.py
+++ b/playhouse/tests/test_migrate.py
@@ -606,14 +606,14 @@ class SqliteMigrationTestCase(BaseMigrationTestCase, PeeweeTestCase):
         db = self.migrator.database
         # rename column to table name
         migrate(self.migrator.rename_column('indexmodel', 'first_name', 'indexmodel'))
-        self.assertIn('indexmodel', [column.name for column in db.get_columns('indexmodel')])
-        self.assertIn('indexmodel_indexmodel_last_name',
-                      [index.name for index in db.get_indexes('indexmodel')])
+        self.assertTrue('indexmodel' in [column.name for column in db.get_columns('indexmodel')])
+        self.assertTrue('indexmodel_indexmodel_last_name' in
+                        [index.name for index in db.get_indexes('indexmodel')])
         # rename column back to original name
         migrate(self.migrator.rename_column('indexmodel', 'indexmodel', 'first_name'))
-        self.assertIn('first_name', [column.name for column in db.get_columns('indexmodel')])
-        self.assertIn('indexmodel_first_name_last_name',
-                      [index.name for index in db.get_indexes('indexmodel')])
+        self.assertTrue('first_name' in [column.name for column in db.get_columns('indexmodel')])
+        self.assertTrue('indexmodel_first_name_last_name' in
+                        [index.name for index in db.get_indexes('indexmodel')])
 
 
 @skip_if(lambda: psycopg2 is None)

--- a/playhouse/tests/test_migrate.py
+++ b/playhouse/tests/test_migrate.py
@@ -602,6 +602,19 @@ class SqliteMigrationTestCase(BaseMigrationTestCase, PeeweeTestCase):
              'ON "indexmodel" ("first", "last_name")', [])
         ])
 
+    def test_rename_indexed_column_with_same_name_as_containing_table(self):
+        db = self.migrator.database
+        # rename column to table name
+        migrate(self.migrator.rename_column('indexmodel', 'first_name', 'indexmodel'))
+        self.assertIn('indexmodel', [column.name for column in db.get_columns('indexmodel')])
+        self.assertIn('indexmodel_indexmodel_last_name',
+                      [index.name for index in db.get_indexes('indexmodel')])
+        # rename column back to original name
+        migrate(self.migrator.rename_column('indexmodel', 'indexmodel', 'first_name'))
+        self.assertIn('first_name', [column.name for column in db.get_columns('indexmodel')])
+        self.assertIn('indexmodel_first_name_last_name',
+                      [index.name for index in db.get_indexes('indexmodel')])
+
 
 @skip_if(lambda: psycopg2 is None)
 class PostgresqlMigrationTestCase(BaseMigrationTestCase, PeeweeTestCase):


### PR DESCRIPTION
When renaming a column with the same name as the table
the table name will get accidentally replaced in the “CREATE index”
query:

```sql
CREATE INDEX
 "table_name_first_column_second_column" ON   
 "table_name" ("first_column", "second_column")
```