### PR TITLE
Explicitly check database for None in ModelOptions

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4466,7 +4466,7 @@ class ModelOptions(object):
         self.valid_fields = set()
         self.declared_fields = []
 
-        self.database = database or default_database
+        self.database = database if database is not None else default_database
         self.db_table = db_table
         self.db_table_func = db_table_func
         self.indexes = list(indexes or [])


### PR DESCRIPTION
I was trying to use Werkzeug's [`LocalProxy`](http://werkzeug.pocoo.org/docs/0.11/local/) with the [Context Usage approach described in the Flask docs](http://flask.pocoo.org/docs/0.11/appcontext/#context-usage):

```python
import peewee
from werkzeug.local import LocalProxy


@LocalProxy
def db():
    _db = getattr(g, '_db', None)
    if _db is None:
        _db = g._db = db_url.connect(current_app.config['DATABASE_URL'])
    return _db


class BaseModel(peewee.Model):
    class Meta:
        database = db


class MyModel(BaseModel):
    ...

def init_app(app):
    @app.teardown_appcontext
    def teardown_db(exception):
        _db = getattr(g, '_db', None)
        if _db and not _db.is_closed():
            _db.close()
        g._db = None
```

The above fails because `bool(db)` [returns `False`](https://github.com/pallets/werkzeug/blob/0.11.10/werkzeug/local.py#L322-L326) on unbound proxies, which causes Peewee [to use its `peewee.db` default database](https://github.com/coleifer/peewee/blob/2.8.1/peewee.py#L4263).

This fixes the problem without changing other existing behavior.
