### PR TITLE
fixed a problem with TimestampField resolution

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1277,7 +1277,9 @@ class TimestampField(IntegerField):
             if value == 0:
                 return
             elif self.resolution > 1:
-                value, microseconds = divmod(value, self.resolution)
+                ticks_to_microsecond = 1000000 // self.resolution
+                value, ticks = divmod(value, self.resolution)
+                microseconds = ticks * ticks_to_microsecond
                 return self._conv(value).replace(microsecond=microseconds)
             else:
                 return self._conv(value)

--- a/playhouse/tests/test_fields.py
+++ b/playhouse/tests/test_fields.py
@@ -432,7 +432,7 @@ class TestTimestampField(ModelTestCase):
         t1_db = TimestampModel.get(TimestampModel.local_us == dt)
         self.assertEqual(t1_db.id, t1.id)
         self.assertEqual(t1_db.local_us, dt)
-        self.assertEqual(t1_db.utc_ms, dt.replace(microsecond=654))
+        self.assertEqual(t1_db.utc_ms, dt.replace(microsecond=654000))
         self.assertEqual(t1_db.local,
                          dt.replace(microsecond=0).replace(second=14))
 
@@ -453,7 +453,7 @@ class TestTimestampField(ModelTestCase):
 
         expected = datetime.datetime(2016, 1, 3, 12, 12, 13)
         self.assertEqual(t3_db.local_us, expected.replace(microsecond=654321))
-        self.assertEqual(t3_db.utc_ms, expected.replace(microsecond=654))
+        self.assertEqual(t3_db.utc_ms, expected.replace(microsecond=654000))
         self.assertEqual(t3_db.local, expected.replace(second=14))
 
 


### PR DESCRIPTION
When retrieving a value from the database, TimestampField didn't properly scale the microseconds by the resolution. Instead of using the resolution, it would always assume the fractional portion was in microseconds.

This fixes that by scaling the fractional second portion as a function of the resolution.