### PR TITLE
Fix threadlocal pool

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -3592,9 +3592,10 @@ class Database(object):
                 raise Exception('Error, database not properly initialized '
                                 'before opening connection')
             with self.exception_wrapper():
-                self._local.conn = self._connect(
-                    self.database,
-                    **self.connect_kwargs)
+                if self._local.conn is None:
+                    self._local.conn = self._connect(
+                        self.database,
+                        **self.connect_kwargs)
                 self._local.closed = False
                 self.initialize_connection(self._local.conn)
 

--- a/peewee.py
+++ b/peewee.py
@@ -3586,13 +3586,13 @@ class Database(object):
     def exception_wrapper(self):
         return ExceptionWrapper(self.exceptions)
 
-    def connect(self):
+    def connect(self, nest=False):
         with self._conn_lock:
             if self.deferred:
                 raise Exception('Error, database not properly initialized '
                                 'before opening connection')
             with self.exception_wrapper():
-                if self._local.conn is None:
+                if self._local.conn is None or nest:
                     self._local.conn = self._connect(
                         self.database,
                         **self.connect_kwargs)

--- a/playhouse/test_utils.py
+++ b/playhouse/test_utils.py
@@ -10,6 +10,8 @@ logger = logging.getLogger('peewee')
 class test_database(object):
     def __init__(self, db, models, create_tables=True, drop_tables=True,
                  fail_silently=False):
+        if not isinstance(models, (list, tuple, set)):
+            raise ValueError('%r must be a list or tuple.' % models)
         self.db = db
         self.models = models
         self.create_tables = create_tables


### PR DESCRIPTION
So, I appreciate there are use cases for multiple connections open per thread but please don't shoot me down straight away!

Test code:

```python
from peewee import *
from playhouse.pool import PooledPostgresqlExtDatabase

db = PooledPostgresqlExtDatabase(
    'my_app',
    user='postgres',
    threadlocals=True,
    register_hstore=False
)


def num_conn():
    return len(db._in_use)


print num_conn()
db.connect()
print num_conn()
db.connect()
print num_conn()
db.close()
print num_conn()
db.close()
print num_conn()
```

This outputs (against master):

```bash
(env) alexlatchford@MacBook-Pro peewee $ python test.py 
0
1
2
1
1
```

Obviously results in an unexpected connection leak under normal user circumstances. I'd like to advocate for the introduction of the nesting flag so you can explicitly choose whether you desire this behaviour.

With this patch:

```bash
(env) alexlatchford@MacBook-Pro peewee $ python test.py 
0
1
1
0
0
```

Any comments would be great, this is a bug that's taken me a while to track down and has been affecting us in production so would be great to get a solution in place! (I know ideally we just shouldn't open 2 connections nested, but with several devs, lots of code I'm trying to look for the pragamatic solution to wholly prevent this leaking behaviour)

Cheers,
Alex