### PR TITLE
fix ignore & replace syntax for mysql

### DIFF
--- a/docs/peewee/playhouse.rst
+++ b/docs/peewee/playhouse.rst
@@ -4005,7 +4005,7 @@ Contains utilities helpful when testing peewee projects.
     using a "test-only" database.
 
     :param Database db: Database to use with the given models
-    :param models: a ``list`` of :py:class:`Model` classes to use with the ``db``
+    :param models: a ``list`` or ``tuple`` of :py:class:`Model` classes to use with the ``db``
     :param boolean create_tables: Whether tables should be automatically created
         and dropped.
     :param boolean fail_silently: Whether the table create / drop should fail
@@ -4036,6 +4036,10 @@ Contains utilities helpful when testing peewee projects.
 
                     # Perform assertions on test data inside ctx manager.
                     self.assertEqual(Tweet.timeline('user-0') [...])
+
+                with test_database(test_db, (User,)):
+                    # Test something that just affects user.
+                    self.test_some_user_thing()
 
                 # once we exit the context manager, we're back to using the normal database
 

--- a/peewee.py
+++ b/peewee.py
@@ -1954,7 +1954,9 @@ class QueryCompiler(object):
         model = query.model_class
         alias_map = self.alias_map_class()
         alias_map.add(model, model._meta.db_table)
-        if query._on_conflict:
+        if query._ignore:
+            statement = 'UPDATE IGNORE'
+        elif query._on_conflict:
             statement = 'UPDATE OR %s' % query._on_conflict
         else:
             statement = 'UPDATE'
@@ -1992,6 +1994,8 @@ class QueryCompiler(object):
         alias_map.add(model, model._meta.db_table)
         if query._upsert:
             statement = meta.database.upsert_sql
+        elif query._ignore:
+            statement = 'INSERT IGNORE INTO'
         elif query._on_conflict:
             statement = 'INSERT OR %s INTO' % query._on_conflict
         else:
@@ -3287,17 +3291,23 @@ class UpdateQuery(_WriteQuery):
     def __init__(self, model_class, update=None):
         self._update = update
         self._on_conflict = None
+        self._ignore = False
         super(UpdateQuery, self).__init__(model_class)
 
     def _clone_attributes(self, query):
         query = super(UpdateQuery, self)._clone_attributes(query)
         query._update = dict(self._update)
         query._on_conflict = self._on_conflict
+        query._ignore = self._ignore
         return query
 
     @returns_clone
     def on_conflict(self, action=None):
         self._on_conflict = action
+
+    @returns_clone
+    def ignore(self, ignore=True):
+        self._ignore = ignore
 
     join = not_allowed('joining')
 
@@ -3339,6 +3349,7 @@ class InsertQuery(_WriteQuery):
         self._query = query
         self._validate_fields = validate_fields
         self._on_conflict = None
+        self._ignore = False
 
     def _iter_rows(self):
         model_meta = self.model_class._meta
@@ -3373,6 +3384,7 @@ class InsertQuery(_WriteQuery):
         query = super(InsertQuery, self)._clone_attributes(query)
         query._rows = self._rows
         query._upsert = self._upsert
+        query._ignore = self._ignore
         query._is_multi_row_insert = self._is_multi_row_insert
         query._fields = self._fields
         query._query = self._query
@@ -3391,6 +3403,10 @@ class InsertQuery(_WriteQuery):
     @returns_clone
     def on_conflict(self, action=None):
         self._on_conflict = action
+
+    @returns_clone
+    def ignore(self, ignore=True):
+        self._ignore = ignore
 
     @returns_clone
     def return_id_list(self, return_id_list=True):
@@ -3850,7 +3866,7 @@ class SqliteDatabase(Database):
         OP.LIKE: 'GLOB',
         OP.ILIKE: 'LIKE',
     }
-    upsert_sql = 'INSERT OR REPLACE INTO'
+    upsert_sql = 'REPLACE INTO'
 
     def __init__(self, database, pragmas=None, *args, **kwargs):
         self._pragmas = pragmas or []

--- a/playhouse/test_utils.py
+++ b/playhouse/test_utils.py
@@ -10,6 +10,8 @@ logger = logging.getLogger('peewee')
 class test_database(object):
     def __init__(self, db, models, create_tables=True, drop_tables=True,
                  fail_silently=False):
+        if not isinstance(models, (list, tuple, set)):
+            raise ValueError('%r must be a list or tuple.' % models)
         self.db = db
         self.models = models
         self.create_tables = create_tables


### PR DESCRIPTION
2 bugs in peewee.py
1.   `upsert_sql = 'INSERT OR REPLACE INTO'`   will have syntax error for Mysql. So I fix it like `upsert_sql = 'REPLACE INTO'`.
2.  add ignore for mysql   `INSERT OR IGNORE INTO` will have syntax error for Mysql.

Example:
Page.insert(data).ignore().execute()
Page.insert_many(data).ignore().execute()

Generate sql：
'INSERT IGNORE INTO `page` (`manga_id`, `page_num`, `img_url`) VALUES (%s, %s, %s)', [11997, 6, 'http://img.177pic66.com/uploads/2016/05a/00178.jpg']

And you will get mysql warning when you use `ignore` but it can work：

```
/Users/wyx/project/scrap/.env/lib/python3.5/site-packages/pymysql/cursors.py:166: Warning: (1062, "Duplicate entry '6' for key 'page_page_num'")
  result = self._query(query)
```
