### PR TITLE
Added a test to check whether a connection is already open.

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -3601,6 +3601,8 @@ class Database(object):
             if self.deferred:
                 raise Exception('Error, database not properly initialized '
                                 'before opening connection')
+            if not self._local.closed:
+                raise Exception('Connection misuse detected (already connected)')
             self._local.conn = self._create_connection()
             self._local.closed = False
             with self.exception_wrapper:


### PR DESCRIPTION
Most importantly the check prevents from leaking database connections,
which can be disasterous when using connection pools.

Moreover it allows one to catch errors in the code which were caused
by not using database.connect() / database.close() properly.