### PR TITLE
Fix pskel print statement for python3 compatibility

### DIFF
--- a/playhouse/pskel
+++ b/playhouse/pskel
@@ -88,8 +88,8 @@ if __name__ == '__main__':
     ao('-d', '--database', dest='database', default=':memory:')
 
     options, models = parser.parse_args()
-    print render_models(
+    print(render_models(
         models,
         engine=engine_mapping[options.engine],
         database=options.database,
-        logging=options.logging)
+        logging=options.logging))


### PR DESCRIPTION
Invoking pskel under python3 produces an error due to the usage of print statement without parenthesis.