### PR TITLE
Make pskel script installable under usr/bin/

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
     ],
-    scripts = ['pwiz.py'],
+    scripts = ['pwiz.py', 'playhouse/pskel'],
     **setup_kwargs
 )


### PR DESCRIPTION
Currently since pskel script does not have the .py extension, nothing happens when invoking setup.py install with that script. It just exists at the sources. The simplest way to make this script get installed is by adding it at the scripts sections in setup.py, thus making it installable under usr/bin/.