### PR TITLE
Fixed db_field for DateTimeTz in postgres_ext

### DIFF
--- a/playhouse/postgres_ext.py
+++ b/playhouse/postgres_ext.py
@@ -164,7 +164,7 @@ class ArrayField(IndexedFieldMixin, Field):
 
 
 class DateTimeTZField(DateTimeField):
-    db_field = 'datetime_tz'
+    db_field = 'timestamptz'
 
 
 class HStoreField(IndexedFieldMixin, Field):


### PR DESCRIPTION
cause since 9.6 `datetime_tz` is not supported.