### PR TITLE
Fixed renaming unique foreign key in MySQL

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -442,7 +442,9 @@ class MySQLMigrator(SchemaMigrator):
              'FROM information_schema.key_column_usage WHERE '
              'table_schema = DATABASE() AND '
              'table_name = %s AND '
-             'column_name = %s;'),
+             'column_name = %s AND '
+             'referenced_table_name IS NOT NULL AND '
+             'referenced_column_name IS NOT NULL;'),
             (table, column_name))
         result = cursor.fetchone()
         if not result:

--- a/playhouse/tests/test_migrate.py
+++ b/playhouse/tests/test_migrate.py
@@ -59,6 +59,10 @@ class Page(Model):
     name = CharField(max_length=100, unique=True, null=True)
     user = ForeignKeyField(User, null=True, related_name='pages')
 
+class Session(Model):
+    user = ForeignKeyField(User, unique=True, related_name='sessions')
+    updated_at = DateField(null=True)
+
 class IndexModel(Model):
     first_name = CharField()
     last_name = CharField()
@@ -75,6 +79,7 @@ MODELS = [
     Tag,
     User,
     Page,
+    Session
 ]
 
 class BaseMigrationTestCase(object):
@@ -493,6 +498,19 @@ class BaseMigrationTestCase(object):
         self.assertEqual(foreign_key.dest_column, 'id')
         self.assertEqual(foreign_key.dest_table, 'users')
 
+    def test_rename_unique_foreign_key(self):
+        migrate(self.migrator.rename_column('session', 'user_id', 'huey_id'))
+        columns = self.database.get_columns('session')
+        self.assertEqual(
+            sorted(column.name for column in columns),
+            ['huey_id', 'id', 'updated_at'])
+
+        foreign_keys = self.database.get_foreign_keys('session')
+        self.assertEqual(len(foreign_keys), 1)
+        foreign_key = foreign_keys[0]
+        self.assertEqual(foreign_key.column, 'huey_id')
+        self.assertEqual(foreign_key.dest_column, 'id')
+        self.assertEqual(foreign_key.dest_table, 'users')
 
 class SqliteMigrationTestCase(BaseMigrationTestCase, PeeweeTestCase):
     database = sqlite_db


### PR DESCRIPTION
When i trying to rename unique foreign key in MySQL, i got error: 
`peewee.OperationalError: (1091, "Can't DROP '...'; check that column/key exists")`

Here is a demo code:
```python
# coding: utf8
import logging

from peewee import MySQLDatabase, Model, ForeignKeyField, IntegerField
from playhouse.migrate import MySQLMigrator, migrate

db = MySQLDatabase(host='prl-s.shared', user='root', database='test')

logger = logging.getLogger('peewee')
logger.setLevel(logging.DEBUG)
logger.addHandler(logging.StreamHandler())


class ModelA(Model):
    class Meta:
        database = db


class ModelB(Model):
    a = ForeignKeyField(ModelA, unique=True)

    class Meta:
        database = db

db.connect()
db.execute_sql('drop table if exists modelb, modela')
ModelA.create_table()
ModelB.create_table()

migrator = MySQLMigrator(db)
migrate(
    migrator.rename_column('modelb', 'a_id', 'a_id_renamed')
)
```

Output:
```
('drop table if exists modelb, modela', None)
('CREATE TABLE `modela` (`id` INTEGER AUTO_INCREMENT NOT NULL PRIMARY KEY)', [])
('CREATE TABLE `modelb` (`id` INTEGER AUTO_INCREMENT NOT NULL PRIMARY KEY, `a_id` INTEGER NOT NULL, `foo` INTEGER, FOREIGN KEY (`a_id`) REFERENCES `modela` (`id`))', [])
('CREATE UNIQUE INDEX `modelb_a_id` ON `modelb` (`a_id`)', [])
('\n            SELECT column_name, referenced_table_name, referenced_column_name\n            FROM information_schema.key_column_usage\n            WHERE table_name = %s\n                AND table_schema = DATABASE()\n                AND referenced_table_name IS NOT NULL\n                AND referenced_column_name IS NOT NULL', ('modelb',))
('DESCRIBE modelb;', None)
('SELECT constraint_name FROM information_schema.key_column_usage WHERE table_schema = DATABASE() AND table_name = %s AND column_name = %s;', ('modelb', 'a_id'))
(u'ALTER TABLE `modelb` DROP FOREIGN KEY `modelb_a_id`', [])
Traceback (most recent call last):
  File '_.py", line 33, in <module>
    migrator.rename_column('modelb', 'a_id', 'a_id_renamed')
  File "/peewee/playhouse/migrate.py", line 711, in migrate
    operation.run()
  File "/peewee/playhouse/migrate.py", line 144, in run
    getattr(self.migrator, self.method)(*self.args, **kwargs))
  File "/peewee/playhouse/migrate.py", line 138, in _handle_result
    self._handle_result(item)
  File "/peewee/playhouse/migrate.py", line 135, in _handle_result
    result.run()
  File "/peewee/playhouse/migrate.py", line 144, in run
    getattr(self.migrator, self.method)(*self.args, **kwargs))
  File "/peewee/playhouse/migrate.py", line 133, in _handle_result
    self.execute(result)
  File "/peewee/playhouse/migrate.py", line 129, in execute
    self.migrator.database.execute_sql(sql, params)
  File "/peewee/peewee.py", line 3714, in execute_sql
    self.commit()
  File "/peewee/peewee.py", line 3537, in __exit__
    reraise(new_type, new_type(*exc_args), traceback)
  File "/peewee/peewee.py", line 3707, in execute_sql
    cursor.execute(sql, params or ())
  File "/usr/lib/python2.7/dist-packages/MySQLdb/cursors.py", line 174, in execute
    self.errorhandler(self, exc, value)
  File "/usr/lib/python2.7/dist-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
    raise errorclass, errorvalue
peewee.OperationalError: (1091, "Can't DROP 'modelb_a_id'; check that column/key exists")
```

This pull request fixes that. Though I'm not sure if i wrote a test case correctly.