### PR TITLE
Add support for ON CONFLICT DO NOTHING in Postgres.

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2017,7 +2017,7 @@ class QueryCompiler(object):
         alias_map.add(model, model._meta.db_table)
         if query._upsert:
             statement = meta.database.upsert_sql
-        elif query._on_conflict:
+        elif query._on_conflict and query._on_conflict.upper() != 'DO NOTHING':
             statement = 'INSERT OR %s INTO' % query._on_conflict
         else:
             statement = 'INSERT INTO'
@@ -2057,6 +2057,9 @@ class QueryCompiler(object):
                 # Bare insert, use default value for primary key.
                 clauses.append(query.database.default_insert_clause(
                     query.model_class))
+
+        if query._on_conflict and query._on_conflict.upper() == 'DO NOTHING':
+            clauses.append(SQL('ON CONFLICT %s' % query._on_conflict))
 
         if query.is_insert_returning:
             clauses.extend([


### PR DESCRIPTION
I saw in the documentation there is a plan to add support for Postgres 9.5's ON CONFLICT DO UPDATE (i.e. upsert), but I didn't see any mention of ON CONFLICT DO NOTHING. This is one simple way to support the latter, although it does not support adding a **_conflict_target_**.