### PR TITLE
Fixed setting of compound parentheses, fixes #1168

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1746,9 +1746,19 @@ class QueryCompiler(object):
         # We add outer parentheses in the event the compound query is used in
         # the `from_()` clause, in which case we'll need them.
         if node.database.compound_select_parentheses:
-            sql = '((%s) %s (%s))' % (l, node.operator, r)
-        else:
-            sql = '(%s %s %s)' % (l, node.operator, r)
+            # only add parentheses around non-compound queries, so that SQL syntax stays correct
+            if first_q._node_type != csq:
+                if inv:
+                    r = '(%s)' % r
+                else:
+                    l = '(%s)' % l
+            if second_q._node_type != csq:
+                if inv:
+                    l = '(%s)' % l
+                else:
+                    r = '(%s)' % r
+
+        sql = '(%s %s %s)' % (l, node.operator, r)
         return  sql, lp + rp
 
     def _parse_select_query(self, node, alias_map, conv):

--- a/playhouse/tests/test_compound_queries.py
+++ b/playhouse/tests/test_compound_queries.py
@@ -163,8 +163,8 @@ class TestCompoundSelectSQL(PeeweeTestCase):
         compound = lhs | queries[2]
         sql, params = compound.sql()
         self.assertEqual(sql, (
-            '((SELECT "t1"."alpha" FROM "alpha" AS t1) UNION '
-            '(SELECT "t2"."alpha" FROM "alpha" AS t2)) UNION '
+            '(SELECT "t1"."alpha" FROM "alpha" AS t1) UNION '
+            '(SELECT "t2"."alpha" FROM "alpha" AS t2) UNION '
             '(SELECT "t3"."alpha" FROM "alpha" AS t3)'))
 
         lhs = queries[0]
@@ -172,8 +172,8 @@ class TestCompoundSelectSQL(PeeweeTestCase):
         sql, params = compound.sql()
         self.assertEqual(sql, (
             '(SELECT "t3"."alpha" FROM "alpha" AS t3) UNION '
-            '((SELECT "t1"."alpha" FROM "alpha" AS t1) UNION '
-            '(SELECT "t2"."alpha" FROM "alpha" AS t2))'))
+            '(SELECT "t1"."alpha" FROM "alpha" AS t1) UNION '
+            '(SELECT "t2"."alpha" FROM "alpha" AS t2)'))
 
     def test_inner_limit(self):
         compound_db.compound_select_parentheses = True


### PR DESCRIPTION
This PR fixes the issue in #1168 by only wrapping non-compound queries in parentheses.

Changed the corresponding test as well.