### PR TITLE
Give TypeError if calling 'update', etc. from Model instance instead of from class

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4832,6 +4832,21 @@ class Model(with_metaclass(BaseModel)):
         for k, v in kwargs.items():
             setattr(self, k, v)
 
+    def __getattribute__(self, item):
+        classmethods = [
+            'alias', 'select', 'update', 'insert', 'insert_many',
+            'insert_from', 'delete', 'raw', 'create', 'get', 'get_or_create',
+            'create_or_get', 'filter', 'table_exists', 'create_table',
+            'table_exists', '_fields_to_index', '_index_data',
+            '_create_indexes', '_drop_indexes', 'sqlall', 'drop_table',
+            'truncate_table', 'as_entity', 'noop']
+
+        if item in classmethods:
+            raise TypeError("'%s' should be called on the class "
+                            "and not the instance" % item)
+
+        return super(Model, self).__getattribute__(item)
+
     @classmethod
     def alias(cls):
         return ModelAlias(cls)
@@ -5075,12 +5090,12 @@ class Model(with_metaclass(BaseModel)):
                     field_dict.pop(pk_part_name, None)
             else:
                 field_dict.pop(pk_field.name, None)
-            rows = self.update(**field_dict).where(self._pk_expr()).execute()
+            rows = self.__class__.update(**field_dict).where(self._pk_expr()).execute()
         elif pk_field is None:
-            self.insert(**field_dict).execute()
+            self.__class__.insert(**field_dict).execute()
             rows = 1
         else:
-            pk_from_cursor = self.insert(**field_dict).execute()
+            pk_from_cursor = self.__class__.insert(**field_dict).execute()
             if pk_from_cursor is not None:
                 pk_value = pk_from_cursor
             self._set_pk_value(pk_value)
@@ -5097,7 +5112,7 @@ class Model(with_metaclass(BaseModel)):
 
     def dependencies(self, search_nullable=False):
         model_class = type(self)
-        query = self.select().where(self._pk_expr())
+        query = self.__class__.select().where(self._pk_expr())
         stack = [(type(self), query)]
         seen = set()
 
@@ -5127,7 +5142,7 @@ class Model(with_metaclass(BaseModel)):
                     model.update(**{fk.name: None}).where(query).execute()
                 else:
                     model.delete().where(query).execute()
-        return self.delete().where(self._pk_expr()).execute()
+        return self.__class__.delete().where(self._pk_expr()).execute()
 
     def __hash__(self):
         return hash((self.__class__, self._get_pk_value()))

--- a/playhouse/tests/test_models.py
+++ b/playhouse/tests/test_models.py
@@ -164,6 +164,12 @@ class TestQueryingModels(ModelTestCase):
 
         self.assertRaises(KeyError, User.update, doesnotexist='invalid')
 
+    if sys.version_info >= (2,7):
+        def test_update_from_instance(self):
+            user = User(username='u1')
+            with self.assertRaises(TypeError):
+                user.update(username='u2')
+
     def test_update_subquery(self):
         User.create_users(3)
         u1, u2, u3 = [user for user in User.select().order_by(User.id)]


### PR DESCRIPTION
I hit a snag with this that took me hours to debug. Since these methods really only make sense as class methods, I don't you should to be able to call them from an instance.