### PR TITLE
Make Model.get(val = None) work the same as Model.select().where(Model.val == None)

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2822,11 +2822,13 @@ class Query(Node):
             if '__' in key and key.rsplit('__', 1)[1] in DJANGO_MAP:
                 key, op = key.rsplit('__', 1)
                 op = DJANGO_MAP[op]
+            elif value is None:
+                op = OP.IS
             else:
                 op = OP.EQ
             for piece in key.split('__'):
                 model_attr = getattr(curr, piece)
-                if isinstance(model_attr, relationship):
+                if value is not None and isinstance(model_attr, relationship):
                     curr = model_attr.rel_model
                     joins.append(model_attr)
             accum.append(Expression(model_attr, op, value))


### PR DESCRIPTION
Currently `Model.select().where(val == None)` compiles into a `WHERE val IS NULL` clause. On the other hand `Model.get(val = None)` compiled into `WHERE val = NULL` and, if val is an FK field, tried to join.

With this PR, this is fixed and Model.get behaves just like Model.select().where()