### PR TITLE
SQLite Closure Tables: Allow for many-to-many relations

### DIFF
--- a/docs/peewee/playhouse.rst
+++ b/docs/peewee/playhouse.rst
@@ -773,6 +773,8 @@ sqlite_ext API notes
 
     :param model_class: The model class containing the nodes in the tree.
     :param foreign_key: The self-referential parent-node field on the model class. If not provided, peewee will introspect the model to find a suitable key.
+    :param referencing_class: The intermediate table for a many-to-many relationship.
+    :param id_column: For a many-to-many relationship: the originating side of the relation.
     :return: Returns a :py:class:`VirtualModel` for working with a closure table.
 
     .. warning:: There are two caveats you should be aware of when using the ``transitive_closure`` extension. First, it requires that your *source model* have an integer primary key. Second, it is strongly recommended that you create an index on the self-referential foreign key.

--- a/playhouse/sqlite_ext.py
+++ b/playhouse/sqlite_ext.py
@@ -667,8 +667,11 @@ class FTS5Model(BaseFTSModel):
         return getattr(cls, attr)
 
 
-def ClosureTable(model_class, foreign_key=None):
+def ClosureTable(model_class, foreign_key=None, referencing_class=None, id_column=None):
     """Model factory for the transitive closure extension."""
+    if referencing_class is None:
+        referencing_class = model_class
+
     if foreign_key is None:
         for field_obj in model_class._meta.rel.values():
             if field_obj.rel_model is model_class:
@@ -678,6 +681,9 @@ def ClosureTable(model_class, foreign_key=None):
             raise ValueError('Unable to find self-referential foreign key.')
 
     primary_key = model_class._meta.primary_key
+
+    if id_column is None:
+        id_column = primary_key
 
     class BaseClosureTable(VirtualModel):
         depth = VirtualIntegerField()
@@ -718,17 +724,33 @@ def ClosureTable(model_class, foreign_key=None):
 
         @classmethod
         def siblings(cls, node, include_node=False):
-            fk_value = node._data.get(foreign_key.name)
-            query = model_class.select().where(foreign_key == fk_value)
+            if referencing_class is model_class:
+                # self-join
+                fk_value = node._data.get(foreign_key.name)
+                query = model_class.select().where(foreign_key == fk_value)
+            else:
+                # siblings as given in reference_class
+                siblings = (referencing_class
+                        .select(id_column)
+                        .join(cls, on=(foreign_key == cls.root))
+                        .where((cls.id == node) & (cls.depth == 1)))
+
+                # the according models
+                query = (model_class
+                     .select()
+                     .where(primary_key << siblings)
+                     .naive())
+
             if not include_node:
                 query = query.where(primary_key != node)
+
             return query
 
     class Meta:
-        database = model_class._meta.database
+        database = referencing_class._meta.database
         extension_options = {
-            'tablename': model_class._meta.db_table,
-            'idcolumn': model_class._meta.primary_key.db_column,
+            'tablename': referencing_class._meta.db_table,
+            'idcolumn': id_column.db_column,
             'parentcolumn': foreign_key.db_column}
         primary_key = False
 

--- a/playhouse/sqlite_ext.py
+++ b/playhouse/sqlite_ext.py
@@ -682,8 +682,8 @@ def ClosureTable(model_class, foreign_key=None):
     class BaseClosureTable(VirtualModel):
         depth = VirtualIntegerField()
         id = VirtualIntegerField()
-        idcolumn = VirtualIntegerField()
-        parentcolumn = VirtualIntegerField()
+        idcolumn = VirtualCharField()
+        parentcolumn = VirtualCharField()
         root = VirtualIntegerField()
         tablename = VirtualCharField()
 


### PR DESCRIPTION
Currently, the ClosureTable only allows for self-joins using the same table. But if you have many-to-many relations between one table using an intermediate table that was not expressible.

With this PR, a self-many-to-many-relation is now supported (as rare as it might be -- I needed it ;)).

I also took the liberty to update the documentation, but this probably could use a second look. 