### PR TITLE
Use `get_primary_key_fields()` instead of `primary_key`, because the former knows how to handle composite keys

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1784,10 +1784,9 @@ class QueryCompiler(object):
         clone = node.clone()
         if not node._explicit_selection:
             if conv and isinstance(conv, ForeignKeyField):
-                select_field = conv.to_field
+                clone._select = (conv.to_field,)
             else:
-                select_field = clone.model_class._meta.primary_key
-            clone._select = (select_field,)
+                clone._select = clone.model_class._meta.get_primary_key_fields()
         sub, params = self.generate_select(clone, alias_map)
         return '(%s)' % strip_parens(sub), params
 


### PR DESCRIPTION
There is already a method `get_primary_key_fields()` which does just what is expected: return the list of all primary key fields, also handling CompositeKeys just right.

There are probably some more instances throughout the code, where using that method instead of `primary_key` would be advisable.

This should fix isse #1219.