### PR TITLE
Model generator support tables with no primary key

### DIFF
--- a/pwiz.py
+++ b/pwiz.py
@@ -111,6 +111,8 @@ def print_models(introspector, tables=None, preserve_order=False):
                 if col in primary_keys])
             pk_list = ', '.join("'%s'" % pk for pk in pk_field_names)
             print_('        primary_key = CompositeKey(%s)' % pk_list)
+        else if not primary_keys:
+            print_('        primary_key = False')
         print_('')
 
         seen.add(table)


### PR DESCRIPTION
Currently for tables with no primary key, pwiz would generate model files without `primary_key = False`. Thus peewee assumes that there is a `id` column as primary key in the table, and the query failed.

Add `primary_key = False` in the `Meta` definition would prevent this error.