### PR TITLE
Implement __ne__ for CompositeKey.

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1578,6 +1578,11 @@ class CompositeKey(object):
                        for field, value in zip(self.field_names, other)]
         return reduce(operator.and_, expressions)
 
+    def __ne__(self, other):
+        expressions = [(self.model_class._meta.fields[field] != value)
+                       for field, value in zip(self.field_names, other)]
+        return reduce(operator.or_, expressions)
+
     def __hash__(self):
         return hash((self.model_class.__name__, self.field_names))
 


### PR DESCRIPTION
For a model with a single primary key, you can do both of these:

```python
(obj._meta.primary_key == obj._get_pk_value())
(obj._meta.primary_key != obj._get_pk_value())
```

And both return a `peewee.Expression` object.

However if the primary key happens to be CompositeKey, the `!=` compare returns `False`.

This fixes that. I can write tests if you'd like.