### PR TITLE
Database URL extension for retrieving endpoint information from AWS RDS

### DIFF
--- a/playhouse/rds_ext.py
+++ b/playhouse/rds_ext.py
@@ -1,0 +1,91 @@
+import boto3
+from botocore.exceptions import ClientError
+
+try:
+    from urlparse import ParseResult
+except ImportError:
+    from urllib.parse import ParseResult
+
+
+class UnsupportedRdsEngine(Exception):
+    """
+    Raised when the RDS DB engine is not supported by the URL building code.
+    """
+    pass
+
+
+def _db_from_boto3_cluster_response(response, read_only=False):
+    cluster = response['DBClusters'][0]
+    hkey = 'ReaderEndpoint' if read_only else 'Endpoint'
+    fields = ['Engine', hkey, 'Port', 'DatabaseName', 'MasterUsername']
+    return tuple(cluster[a] for a in fields)
+
+
+def _db_from_boto3_instance_response(response, **kwargs):
+    instance = response['DBInstances'][0]
+    db0 = tuple(instance[a] for a in ['Engine', 'DBName', 'MasterUsername'])
+    db1 = tuple(instance['Endpoint'][a] for a in ['Address', 'Port'])
+    return (db0[0], db1[0], db1[1], db0[1], db0[2])
+
+
+def parse_from_rds(parsed):
+    """
+    Retrieve the parsed database endpoint URL from a parsed rds:// or rdsro://
+    URL.
+
+    The RDS cluster or RDS instance id is read from parsed.hostname (it is case
+    insensitive), then boto3 is used to retrieve the DB information (db engine,
+    db name, db endpoint address and port) so that the parsed database URL can
+    be built.
+
+    The rds:// scheme retrieves the read-write endpoint of the RDS cluster or
+    RDS instance, while rdsro:// retrieves the read-only endpoint of the RDS
+    cluster. Since there are no read-only endpoints for an RDS instance, in
+    this case rdsro:// is equivalent to rds:// .
+
+    See also:
+    https://boto3.readthedocs.io/en/latest/reference/services/rds.html#client
+
+    :type parsed: urlparse.ParseResult
+    :param parsed: rds:// or rdsro:// parsed URL.
+    :rtype: urlparse.ParseResult
+    :returns: Parsed URL for the RDS database.
+    """
+    assert parsed.scheme in ['rds', 'rdsro'], "rds_ext only supports the " \
+        "rds:// and rdsro:// schemes: '{}://' provided".format(parsed.scheme)
+    db_id = parsed.hostname
+    ro = (parsed.scheme == 'rdsro')
+
+    # query boto3's rds client for DB description
+    rds = boto3.client('rds')
+    try:
+        response = rds.describe_db_clusters(DBClusterIdentifier=db_id)
+        dbinfo = _db_from_boto3_cluster_response
+    except ClientError:
+        response = rds.describe_db_instances(DBInstanceIdentifier=db_id)
+        dbinfo = _db_from_boto3_instance_response
+    engine, hostname, port, dbname, username = dbinfo(response, read_only=ro)
+
+    # recover playhouse-compatible scheme from RDS engine
+    # RDS engines not supported yet: 'oracle-ee' and 'sqlserver-*'
+    rds_scheme_map = {
+        'aurora': 'mysql',
+        'mysql': 'mysql',
+        'mariadb': 'mysql',
+        'postgres': 'postgres',
+    }
+    try:
+        scheme = rds_scheme_map[engine]
+    except KeyError:
+        raise UnsupportedRdsEngine('Unsupported RDS Engine "{}"'.format(engine))
+    # 1. hostname and port are provided by RDS
+    netloc = '{}:{}'.format(hostname, port)
+    # 2. if dbname or username was provided, overwrite the default ones from RDS
+    dbname = parsed.path if parsed.path else '/'+dbname
+    username = parsed.username if parsed.username else username
+    # 3. the password is never provided by RDS
+    if parsed.password:
+        netloc = '{}:{}@{}'.format(username, parsed.password, netloc)
+    else:
+        netloc = '{}@{}'.format(username, netloc)
+    return ParseResult(scheme, netloc, dbname, *parsed[3:])

--- a/playhouse/rds_ext.py
+++ b/playhouse/rds_ext.py
@@ -7,9 +7,9 @@ except ImportError:
     from urllib.parse import ParseResult
 
 
-class UnsupportedRdsEngine(Exception):
+class UnsupportedAwsRdsEngine(Exception):
     """
-    Raised when the RDS DB engine is not supported by the URL building code.
+    Raised when the AWS RDS DB engine is not supported by the URL building code.
     """
     pass
 
@@ -33,15 +33,15 @@ def parse_from_rds(parsed):
     Retrieve the parsed database endpoint URL from a parsed rds:// or rdsro://
     URL.
 
-    The RDS cluster or RDS instance id is read from parsed.hostname (it is case
-    insensitive), then boto3 is used to retrieve the DB information (db engine,
-    db name, db endpoint address and port) so that the parsed database URL can
-    be built.
+    The AWS RDS cluster or AWS RDS instance id is read from parsed.hostname (it
+    is case insensitive), then boto3 is used to retrieve the DB information (db
+    engine, db name, db endpoint address and port) so that the parsed database
+    URL can be built.
 
-    The rds:// scheme retrieves the read-write endpoint of the RDS cluster or
-    RDS instance, while rdsro:// retrieves the read-only endpoint of the RDS
-    cluster. Since there are no read-only endpoints for an RDS instance, in
-    this case rdsro:// is equivalent to rds:// .
+    The rds:// scheme retrieves the read-write endpoint of the AWS RDS cluster
+    or AWS RDS instance, while rdsro:// retrieves the read-only endpoint of the
+    AWS RDS cluster. Since there are no read-only endpoints for an AWS RDS
+    instance, in this case rdsro:// is equivalent to rds:// .
 
     See also:
     https://boto3.readthedocs.io/en/latest/reference/services/rds.html#client
@@ -49,7 +49,7 @@ def parse_from_rds(parsed):
     :type parsed: urlparse.ParseResult
     :param parsed: rds:// or rdsro:// parsed URL.
     :rtype: urlparse.ParseResult
-    :returns: Parsed URL for the RDS database.
+    :returns: Parsed URL for the AWS RDS database.
     """
     assert parsed.scheme in ['rds', 'rdsro'], "rds_ext only supports the " \
         "rds:// and rdsro:// schemes: '{}://' provided".format(parsed.scheme)
@@ -77,7 +77,8 @@ def parse_from_rds(parsed):
     try:
         scheme = rds_scheme_map[engine]
     except KeyError:
-        raise UnsupportedRdsEngine('Unsupported RDS Engine "{}"'.format(engine))
+        raise UnsupportedAwsRdsEngine('Unsupported AWS RDS Engine '
+                                      '"{}"'.format(engine))
     # 1. hostname and port are provided by RDS
     netloc = '{}:{}'.format(hostname, port)
     # 2. if dbname or username was provided, overwrite the default ones from RDS


### PR DESCRIPTION
This pull-request adds an extension to playhouse's database URL mechanism to handle two new URL schemes, namely rds:// and rdsro:// (for rds "read-only"). These schemes simplify the use of AWS' Relational Database Service (RDS).

Through boto3 (the main python SDK for AWS), RDS can provide the host endpoint (rw or ro), its port, the master username and the database engine type (mysql, postgresql, aurora and mariadb supported for far in this patch) to any authorised AWS users, from just the database id (a case-insensitive string). With this information, it is then easy to build the actual database URL for peewee/playhouse to use for connecting.

For instance, one could provide the simple url "rds://test_db_user:test_db_pass@test_rds_db_id" which would automatically resolve to "mysql://test_db_user:test_db_pass@test_rds_db.ceqrivboeuyrbj.us-west-2.rds.amazonaws.com:5555/testdb" (assuming the RDS instance is mysql-compatible, listening on port 5555, etc.). The benefit is that the URL does not need to be changed as one manages its RDS database (changing the port, replacing hosts, adding replication and growing the fleet, etc.)

The main idea of the patch is to provide the function that converts a parsed rds:// or rdsro:// url into the corresponding parsed mysql:// or postgresql:// URL (dynamically determined depending on the engine type). The commit also provides a mechanism to add more such functions to resolve parsed URLs into new parsed URLs. Potential applications for this mechanism include reading database URLs or passwords from environment variables, configuration files, else other secret-sharing services (those applications are left for future pull requests).

Looking forward to comments and suggestions!