### PR TITLE
Add clear explanations about the implications of SQLite having foreign keys off by default, in combination with default PrimaryKeyField ID reuse.

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -515,6 +515,9 @@ Fields
 
     Stores: auto-incrementing integer fields suitable for use as primary key.
 
+    .. note::
+        In SQLite, for performance reasons, the default primary key type simply uses the max existing value + 1 for new values, as opposed to the max ever value + 1. This means deleted records can have their primary keys reused. In conjunction with SQLite having foreign keys disabled by default (meaning ON DELETE is ignored, even if you specify it explicitly), this can lead to surprising and dangerous behaviour. To avoid this, you may want to use one or both of :py:class:`PrimaryKeyAutoIncrementField` and `pragmas=(('foreign_keys', 'on'),)` when you instantiate `SqliteDatabase`.
+
     .. py:attribute:: db_field = 'primary_key'
 
 .. py:class:: FloatField

--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -728,7 +728,7 @@ Fields
 
     :param rel_model: related :py:class:`Model` class or the string 'self' if declaring a self-referential foreign key
     :param string related_name: attribute to expose on related model
-    :param string on_delete: on delete behavior, e.g. ``on_delete='CASCADE'``.
+    :param string on_delete: on delete behavior, e.g. ``on_delete='CASCADE'``. Note this has no effect in SQLite if you don't specify `pragmas=(('foreign_keys', 'on'),)` on database init.
     :param string on_update: on update behavior.
     :param to_field: the field (or field name) on ``rel_model`` the foreign key
         references. Defaults to the primary key field for ``rel_model``.
@@ -759,6 +759,8 @@ Fields
 
     .. note:: If you manually specify a ``to_field``, that field must be either
         a primary key or have a unique constraint.
+
+    .. note:: Take care with foreign keys in SQLite. By default, ON DELETE has no effect, which can have surprising (and usually unwanted) effects on your database integrity. This can affect you even if you don't specify on_delete, since the default ON DELETE behaviour (to fail without modifying your data) does not happen, and your data can be silently relinked. The safest thing to do is to specify `pragmas=(('foreign_keys', 'on'),)` when you instantiate `SqliteDatabase`.
 
 .. py:class:: CompositeKey(*fields)
 

--- a/docs/peewee/querying.rst
+++ b/docs/peewee/querying.rst
@@ -1153,6 +1153,10 @@ Foreign Keys
 
 Foreign keys are created using a special field class :py:class:`ForeignKeyField`. Each foreign key also creates a back-reference on the related model using the specified *related_name*.
 
+.. note::
+    In SQLite, foreign keys are not enabled by default. Most things, including the Peewee foreign-key API, will work fine, but ON DELETE behaviour will be ignored, even if you explicitly specify on_delete to your ForeignKeyField. In conjunction with the default PrimaryKeyField behaviour (where deleted record IDs can be reused), this can lead to surprising (and almost certainly unwanted) behaviour where if you delete a record in table A referenced by a foreign key in table B, and then create a new, unrelated, record in table A, the new record will end up mis-attached to the undeleted record in table B. To avoid the mis-attachment, you can use :py:class:`PrimaryKeyAutoIncrementField`, but it may be better overall to ensure that foreign keys are enabled with `pragmas=(('foreign_keys', 'on'),)` when you instantiate `SqliteDatabase`.
+
+
 Traversing foreign keys
 -----------------------
 


### PR DESCRIPTION
To address the problems raised in #550 
