### PR TITLE
Do not force primary_key value on returning clause

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2125,17 +2125,18 @@ class QueryCompiler(object):
                 clauses.append(query.database.default_insert_clause(
                     query.model_class))
 
-        if query.is_insert_returning:
+        if query._returning is not None:
+            # Return the fields asked for.
+            returning_clause = Clause(*query._returning)
+            returning_clause.glue = ', '
+            clauses.extend([SQL('RETURNING'), returning_clause])
+        elif query.is_insert_returning:
+            # Return the primary keys.
             clauses.extend([
                 SQL('RETURNING'),
                 self._get_field_clause(
                     meta.get_primary_key_fields(),
                     clause_type=CommaClause)])
-        elif query._returning is not None:
-            returning_clause = Clause(*query._returning)
-            returning_clause.glue = ', '
-            clauses.extend([SQL('RETURNING'), returning_clause])
-
 
         return self.build_query(clauses, alias_map)
 


### PR DESCRIPTION
Using Postgresql, when calling `.returning(*)` on an `InsertQuery`, the `RETURNING` clause was always set to my single primary_key.
I simply inverted the two possible returning clauses to ensure `.returning()` takes the priority.