### PR TITLE
Document exception hierarchy

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -2717,6 +2717,22 @@ Metadata Types
 
         The name of the table containing this foreign key.
 
+Exception Hierarchy
+-------------------
+
+::
+
+  PeeweeException
+   +-- DatabaseError
+        +-- DataError
+        +-- IntegrityError
+        +-- InternalError
+        +-- NotSupportedError
+        +-- OperationalError
+        +-- ProgrammingError
+   +-- ImproperlyConfigured
+   +-- InterfaceError
+
 Misc
 ----
 


### PR DESCRIPTION
Sometimes I want to make sure I'm catching all possible peewee exceptions, but not knowing the base exception makes it hard. Having the exception hierarchy in API docs (inspired by [docs for built-in exceptions][1]) could be handy for this.

[1]: https://docs.python.org/3/library/exceptions.html#exception-hierarchy