### PR TITLE
Fix how set's are translated to SQL

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1080,7 +1080,7 @@ class Value(ColumnBase):
     def __init__(self, value, converter=None, unpack=True):
         self.value = value
         self.converter = converter
-        self.multi = isinstance(self.value, (list, tuple)) and unpack
+        self.multi = isinstance(self.value, (list, tuple, set)) and unpack
         if self.multi:
             self.values = []
             for item in self.value:


### PR DESCRIPTION
The following code breaks from 2 to 3

```python
import peewee
from peewee import *

db = SqliteDatabase(':memory:')

class MyModel(Model):
  class Meta:
    database = db

class Foo(MyModel):
  name = CharField()

print(peewee.__version__)
print(Foo.select().where(Foo.name.in_({'foo'})).sql())
```

And the output for each
```
2.10.2
('SELECT "t1"."id", "t1"."name" FROM "foo" AS t1 WHERE ("t1"."name" IN (?))', ['foo'])

```
```
3.0.5
('SELECT "t1"."id", "t1"."name" FROM "foo" AS "t1" WHERE ("t1"."name" IN ?)', ["{'foo'}"])
```

Given how the conversion used to include `set`s ([this](https://github.com/coleifer/peewee/blob/2.10.2/peewee.py#L1852) is the relavent line I think), this would be the "fix".

If that change was intentional I understand that as well.