### PR TITLE
Fixed unsaved relation population

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -5116,9 +5116,9 @@ class Model(with_metaclass(ModelBase, Node)):
         return new_data
 
     def _populate_unsaved_relations(self, field_dict):
-        for foreign_key in self._meta.refs:
+        for foreign_key_field in self._meta.refs:
+            foreign_key = foreign_key_field.name
             conditions = (
-                foreign_key in self._dirty and
                 foreign_key in field_dict and
                 field_dict[foreign_key] is None and
                 self.__rel__.get(foreign_key) is not None)

--- a/peewee.py
+++ b/peewee.py
@@ -5124,7 +5124,7 @@ class Model(with_metaclass(ModelBase, Node)):
                 self.__rel__.get(foreign_key) is not None)
             if conditions:
                 setattr(self, foreign_key, getattr(self, foreign_key))
-                field_dict[foreign_key] = self._data[foreign_key]
+                field_dict[foreign_key] = self.__data__[foreign_key]
 
     def save(self, force_insert=False, only=None):
         field_dict = self.__data__.copy()


### PR DESCRIPTION
Fixes #1457

1) The keys in the respective dicts is the foreign key's name, not the field itself.
2) According to `ForeignKeyAccessor.__set__`, foreign key fields are never marked as dirty.