### PR TITLE
Pass kwargs through Function decorator. Fixes #1462

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1225,8 +1225,8 @@ class Function(ColumnBase):
             self._coerce = coerce
 
     def __getattr__(self, attr):
-        def decorator(*args):
-            return Function(attr, args)
+        def decorator(*args, **kwargs):
+            return Function(attr, args, **kwargs)
         return decorator
 
     def over(self, partition_by=None, order_by=None, start=None, end=None,


### PR DESCRIPTION
This enables the user to do for example

``` python
fn.ARRAY_AGG(Some.thing, coerce=False)
```