### PR TITLE
Fix not_in with empty list

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1357,7 +1357,10 @@ class NodeList(ColumnBase):
     def __sql__(self, ctx):
         n_nodes = len(self.nodes)
         if n_nodes == 0:
-            return ctx
+            if self.parens:
+                return ctx.literal('()')
+            else:
+                return ctx
         with ctx(parentheses=self.parens):
             for i in range(n_nodes - 1):
                 ctx.sql(self.nodes[i])

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -113,3 +113,8 @@ class TestQueryExecution(DatabaseTestCase):
 
         query = query.where(Register.value >= 2)
         self.assertEqual(query.scalar(as_tuple=True), (15, 3, 5))
+
+    def test_empty_in_not_in(self):
+        self.assertEqual(User.select().where(User.id.in_([])).count(), 0)
+        self.assertEqual(User.select().where(User.id.not_in([])).count(),
+                         User.select().count())


### PR DESCRIPTION
Using `not_in` with an empty list produces malformed SQL

```python
import peewee
from peewee import *

class MyBase(Model):

    class Meta:
        database = SqliteDatabase(':memory:')

class Foo(MyBase):
    name = CharField()

print(peewee.__version__)
print(Foo.select().where(Foo.name.not_in([])).sql())
```

```
2.10.2
('SELECT "t1"."id", "t1"."name" FROM "foo" AS t1 WHERE ("t1"."name" NOT IN ())', [])
```
```
3.0.10
('SELECT "t1"."id", "t1"."name" FROM "foo" AS "t1" WHERE ("t1"."name" NOT IN )', [])
```

I think (?) that is the right fix. And added a new test to cover it