### PR TITLE
Model.table_exists() now checks whether table exists in its schema

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -5266,7 +5266,7 @@ class Model(with_metaclass(ModelBase, Node)):
 
     @classmethod
     def table_exists(cls):
-        return cls._meta.database.table_exists(cls._meta.table)
+        return cls._meta.database.table_exists(cls._meta.table, cls._meta.schema)
 
     @classmethod
     def create_table(cls, safe=True, **options):


### PR DESCRIPTION
Model.table_exists() with safe=True was checking whether table exists in default schema('public') instead of Model schema.