### PR TITLE
Clarify comment that sounded like create_tables() in Peewee 3 will dr…

### DIFF
--- a/docs/peewee/changes.rst
+++ b/docs/peewee/changes.rst
@@ -22,7 +22,7 @@ Database
   :py:meth:`Database.connection_context`.
 * :py:meth:`Database.create_tables` and :py:meth:`Database.drop_tables`, as
   well as :py:meth:`Model.create_table` and :py:meth:`Model.drop_table` all
-  default to ``safe=True`` (create if not exists, drop if exists).
+  default to ``safe=True`` (``create_table`` will create if not exists, ``drop_table`` will drop if exists).
 * ``connect_kwargs`` attribute has been renamed to ``connect_params``
 
 Model Meta options


### PR DESCRIPTION
…op your table if it exists.

This scared me on first read. I had to read it a couple times to figure out that the second part of the parenthetical comment was talking about the drop_tables() method. And I had to read the source code to be fully sure.

I like the updated functionality, though. It's a great improvement, thanks!