### PR TITLE
Support prefetching ManyToManyFields

### DIFF
--- a/tests/manytomany.py
+++ b/tests/manytomany.py
@@ -107,6 +107,30 @@ class TestManyToMany(ModelTestCase):
         with self.assertQueryCount(2):
             self.assertUsers(Note.create(text='x').users, [])
 
+    def test_prefetch_notes(self):
+        self._set_data()
+        gargie, huey, mickey, zaizee = prefetch(User.select().order_by(User.username), NoteUserThrough, Note)
+
+        with self.assertQueryCount(0):
+            self.assertNotes(gargie.notes, [1, 2])
+        with self.assertQueryCount(0):
+            self.assertNotes(zaizee.notes, [4, 5])
+        with self.assertQueryCount(2):
+            self.assertNotes(User.create(username='x').notes, [])
+
+    def test_prefetch_users(self):
+        self._set_data()
+        n1, n2, n3, n4, n5 = prefetch(Note.select().order_by(Note.text), NoteUserThrough, User)
+
+        with self.assertQueryCount(0):
+            self.assertUsers(n1.users, ['gargie'])
+        with self.assertQueryCount(0):
+            self.assertUsers(n2.users, ['gargie', 'huey'])
+        with self.assertQueryCount(0):
+            self.assertUsers(n5.users, ['zaizee'])
+        with self.assertQueryCount(2):
+            self.assertUsers(Note.create(text='x').users, [])
+
     def test_query_filtering(self):
         self._set_data()
         gargie, huey, mickey, zaizee = User.select().order_by(User.username)


### PR DESCRIPTION
Previously, prefetching a relationship exposed in a ManyToMany field would only expose the through model’s prefetched data. Now, the many to many field correctly exposes the prefetched data via the through field’s prefetched results, rather than requerying what has already been prefetched.