### PR TITLE
Make connecting signals operation idempotent

### DIFF
--- a/playhouse/signals.py
+++ b/playhouse/signals.py
@@ -2,6 +2,7 @@
 Provide django-style hooks for model events.
 """
 from peewee import Model as _Model
+from peewee import logger
 
 
 class Signal(object):
@@ -13,8 +14,13 @@ class Signal(object):
         if name not in self._receivers:
             self._receivers[name] = (receiver, sender)
             self._receiver_list.append(name)
+        elif (receiver, sender) == self._receivers[name]:
+            logger.warning('receiver %s has been already connected' % name)
         else:
-            raise ValueError('receiver named %s already connected' % name)
+            raise ValueError(
+                'receiver %s is already attached to another sender %s' %
+                (name, self._receivers[name][1])
+            )
 
     def disconnect(self, receiver=None, name=None):
         if receiver:

--- a/playhouse/signals.py
+++ b/playhouse/signals.py
@@ -11,16 +11,23 @@ class Signal(object):
 
     def connect(self, receiver, name=None, sender=None):
         name = name or receiver.__name__
+        if (receiver, sender) == self._receivers.get(name):
+            logger.warning('receiver %s has been already connected' % name)
+            return
+
         if name not in self._receivers:
             self._receivers[name] = (receiver, sender)
             self._receiver_list.append(name)
-        elif (receiver, sender) == self._receivers[name]:
-            logger.warning('receiver %s has been already connected' % name)
         else:
-            raise ValueError(
-                'receiver %s is already attached to another sender %s' %
-                (name, self._receivers[name][1])
-            )
+            _, connected_sender = self._receivers[name]
+            if str(sender) != str(connected_sender):
+                raise ValueError(
+                    'receiver %s is already attached to another sender %s' %
+                    (name, connected_sender)
+                )
+            else:
+                # Update code for receiver
+                self._receivers[name] = (receiver, sender)
 
     def disconnect(self, receiver=None, name=None):
         if receiver:

--- a/tests/signals.py
+++ b/tests/signals.py
@@ -125,3 +125,28 @@ class TestSignals(ModelTestCase):
 
         b = SubB.create()
         assert b in state
+
+    def test_assign_same_function_to_signal(self):
+        state = []
+
+        @signals.post_save(sender=B)
+        def post_save_one(sender, instance, created):
+            state.append(instance)
+
+        signals.post_save(sender=B)(post_save_one)
+
+        b = SubB.create()
+        assert b in state
+
+    def test_assign_same_function_another_sender(self):
+        state = []
+
+        @signals.post_save(sender=B)
+        def post_save_one(sender, instance, created):
+            state.append(instance)
+
+        with self.assertRaises(ValueError):
+            signals.post_save(sender=A)(post_save_one)
+
+        b = SubB.create()
+        assert b in state


### PR DESCRIPTION
## Rationale
Attaching receivers should not crash a program. 

## Use cases
1. Module has been reloaded
`m.py`
```
from peewee import *
from playhouse import signals

class A(signals.Model):
    a = TextField(default='')

state = []

@signals.post_save(sender=A)
def post_save(sender, instance, created):
    state.append((sender, instance, instance._pk, created))
```
and `test.py`
```
import m

try:
    from importlib import reload
except ImportError:
    pass

reload(m)
```
will raise `ValueError`.

2. We should allow assigning same receiver multiple times (it should be idempotent) to handle cases like this
`test2.py`
```
from peewee import *
from playhouse import signals


class A(signals.Model):
    a = TextField(default='')


database = SqliteDatabase(':memory:')
A._meta.set_database(database)
A.create_table()

state = []


@signals.post_save(sender=A)
def post_save(sender, instance, created):
    state.append((sender, instance, instance._pk, created))


def ensure_receivers_are_connected():
    # I am not sure whether `flush` was invoked or not at some point
    signals.post_save(sender=A)(post_save)


ensure_receivers_are_connected()

a = A(a='my text')
a.save()
assert len(state) == 1
```
But I guess we still need to prohibit binding in a such way function to different sender. In case you intentionally want to do such a thing you have `disconnect` method.