### PR TITLE
Integration with Sanic

### DIFF
--- a/docs/peewee/database.rst
+++ b/docs/peewee/database.rst
@@ -1079,7 +1079,7 @@ See `Publish/Subscribe pattern
 Sanic
 ^^^^^
 
-The connection handling code can be placed in the request and reponse middleware `sanic middleware
+In Sanic, the connection handling code can be placed in the request and reponse middleware `sanic middleware
 <https://github.com/channelcat/sanic/blob/master/docs/sanic/middleware.md>`_.
 
 .. code-block:: python
@@ -1091,7 +1091,7 @@ The connection handling code can be placed in the request and reponse middleware
 
     @app.middleware('response')
     async def handle_response(request, response):
-        if not db.is_closed()#
+        if not db.is_closed():
             db.close()
 
 Other frameworks

--- a/docs/peewee/database.rst
+++ b/docs/peewee/database.rst
@@ -1076,6 +1076,24 @@ See `Publish/Subscribe pattern
     cherrypy.engine.subscribe('before_request', _db_connect)
     cherrypy.engine.subscribe('after_request', _db_close)
 
+Sanic
+^^^^^
+
+The connection handling code can be placed in the request and reponse middleware `sanic middleware
+<https://github.com/channelcat/sanic/blob/master/docs/sanic/middleware.md>`_.
+
+.. code-block:: python
+
+    # app.py
+    @app.middleware('request')
+    async def handle_request(request):
+        db.connect()
+
+    @app.middleware('response')
+    async def handle_response(request, response):
+        if not db.is_closed()#
+            db.close()
+
 Other frameworks
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Using peewee in a Sanic project and got `Error 2006: MySQL server has gone away`. After implementation of handler in request and response middleware, the error has gone and the application runs well. 