### PR TITLE
Update api.rst for Sqlitedatabase inheritance

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -460,7 +460,7 @@ Database
         set every time a connection is opened.
     :param timeout: Set the busy-timeout on the SQLite driver (in seconds).
 
-    Sqlite database implementation. :py:class:`SqliteDatabase` that provides
+    Sqlite database implementation. :py:class:`SqliteDatabase` inherits from :py:class:`Database` and provides
     some advanced features only offered by Sqlite.
 
     * Register custom aggregates, collations and functions


### PR DESCRIPTION
Adding an explicit indication that Sqlitedatabase inherits from Database; if proposed change is accepted, I can go into the other classes and add similar explicit reference.