### PR TITLE
'Metadata' object has no attribute 'model_ref'

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4826,7 +4826,7 @@ class Metadata(object):
     def remove_ref(self, field):
         rel = field.rel_model
         del self.refs[field]
-        self.model_ref[rel].remove(field)
+        self.model_refs[rel].remove(field)
         del rel._meta.backrefs[field]
         rel._meta.model_backrefs[self.model].remove(field)
 


### PR DESCRIPTION
Fixed mistype in Metadata class. It breaks migrations for now.