### PR TITLE
Fix issue with sort_models and DeferredForeignKey

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -5552,7 +5552,7 @@ def sort_models(models):
     def dfs(model):
         if model in models and model not in seen:
             seen.add(model)
-            for rel_field, rel_model in model._meta.refs.iteritems():
+            for rel_field, rel_model in model._meta.refs.items():
                 if not rel_field.deferred:
                     dfs(rel_model)
             if model._meta.depends_on:

--- a/peewee.py
+++ b/peewee.py
@@ -5552,8 +5552,9 @@ def sort_models(models):
     def dfs(model):
         if model in models and model not in seen:
             seen.add(model)
-            for rel_model in model._meta.refs.values():
-                dfs(rel_model)
+            for rel_field, rel_model in model._meta.refs.iteritems():
+                if not rel_field.deferred:
+                    dfs(rel_model)
             if model._meta.depends_on:
                 for dependency in model._meta.depends_on:
                     dfs(dependency)


### PR DESCRIPTION
I found an issue when using DeferredForeignKey and create_tables. The easiest way to duplicate the issue is to make a small modification to [this](http://docs.peewee-orm.com/en/latest/peewee/models.html#circular-foreign-key-dependencies) example from the peewee docs. 

Here is the original example, which works fine. 

```python
class User(Model):
    username = CharField()
    favorite_tweet = DeferredForeignKey('Tweet', null=True)
class Tweet(Model):
    message = TextField()
    user = ForeignKeyField(User, backref='tweets')

db.create_tables([User, Tweet])
```

However, one small change, and the example no longer works. The change is simply to rename `User` to `AUser`.

```python
class AUser(Model):
    username = CharField()
    favorite_tweet = DeferredForeignKey('Tweet', null=True)

class Tweet(Model):
    message = TextField()
    user = ForeignKeyField(AUser, backref='tweets')

db.create_tables([AUser, Tweet])
```

The original example from the docs works because `Tweet` is alphabetically before `User`, and `sort_models.dfs` gets called in the order: `Tweet` -> `User`. However, if we rename `User` to `AUser`, the call order of `dfs` is now `AUser` -> `Tweet`, therefore causing `Tweet` to be created first. This throws an error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "goals/model/__init__.py", line 54, in create_tables
    db.create_tables([AUser, Tweet])
  File "/usr/lib/python2.7/site-packages/peewee.py", line 2724, in create_tables
    model.create_table(**options)
  File "/usr/lib/python2.7/site-packages/peewee.py", line 5456, in create_table
    cls._schema.create_all(safe, **options)
  File "/usr/lib/python2.7/site-packages/peewee.py", line 4722, in create_all
    self.create_table(safe, **table_options)
  File "/usr/lib/python2.7/site-packages/peewee.py", line 4618, in create_table
    self.database.execute(self._create_table(safe=safe, **options))
  File "/usr/lib/python2.7/site-packages/playhouse/postgres_ext.py", line 446, in execute
    cursor = self.execute_sql(sql, params, commit=commit)
  File "/usr/lib/python2.7/site-packages/peewee.py", line 2583, in execute_sql
    self.commit()
  File "/usr/lib/python2.7/site-packages/peewee.py", line 2376, in __exit__
    reraise(new_type, new_type(*exc_args), traceback)
  File "/usr/lib/python2.7/site-packages/peewee.py", line 2576, in execute_sql
    cursor.execute(sql, params or ())
peewee.ProgrammingError: relation "auser" does not exist
```

The attached pull request fixes the issue by making a small modification to `dfs` in `sort_models`. I've added a check to ensure that deferred foreign keys are not traversed by the dfs. 