### PR TITLE
Fix compatibility with Python 3.7

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -3646,7 +3646,10 @@ class CursorWrapper(object):
     def iterator(self):
         """Efficient one-pass iteration over the result set."""
         while True:
-            yield self.iterate(False)
+            try:
+                yield self.iterate(False)
+            except StopIteration:
+                return
 
     def fill_cache(self, n=0):
         n = n or float('Inf')


### PR DESCRIPTION
Fixes many test failures like below:

```
======================================================================
ERROR: test_iterator (tests.models.TestModelAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/python-peewee/src/peewee-3.5.2/peewee.py", line 3613, in iterator
    yield self.iterate(False)
  File "/build/python-peewee/src/peewee-3.5.2/peewee.py", line 3597, in iterate
    raise StopIteration
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/build/python-peewee/src/peewee-3.5.2/tests/base.py", line 247, in inner
    method(self)
  File "/build/python-peewee/src/peewee-3.5.2/tests/models.py", line 989, in test_iterator
    self.assertEqual([u.username for u in query], users)
  File "/build/python-peewee/src/peewee-3.5.2/tests/models.py", line 989, in <listcomp>
    self.assertEqual([u.username for u in query], users)
RuntimeError: generator raised StopIteration
```

With the patch, all tests pass under both python 3.7 and 2.7 here.