### PR TITLE
Added support for introspecting views for Postgresql.

### DIFF
--- a/playhouse/reflection.py
+++ b/playhouse/reflection.py
@@ -481,12 +481,18 @@ class Introspector(object):
             column = '_' + column
         return column
 
-    def introspect(self, table_names=None, literal_column_names=False):
+    def introspect(self, table_names=None, literal_column_names=False,
+            views_only=False):
+        # Maybe we want the just the views instead of tables.
+        if views_only:
+            func = self.metadata.database.get_views
+        else:
+            func = self.metadata.database.get_tables
         # Retrieve all the tables in the database.
         if self.schema:
-            tables = self.metadata.database.get_tables(schema=self.schema)
+            tables = func(schema=self.schema)
         else:
-            tables = self.metadata.database.get_tables()
+            tables = func()
 
         if table_names is not None:
             tables = [table for table in tables if table in table_names]

--- a/pwiz.py
+++ b/pwiz.py
@@ -43,8 +43,8 @@ def make_introspector(database_type, database_name, **kwargs):
     db = DatabaseClass(database_name, **kwargs)
     return Introspector.from_database(db, schema=schema)
 
-def print_models(introspector, tables=None, preserve_order=False):
-    database = introspector.introspect(table_names=tables)
+def print_models(introspector, tables=None, preserve_order=False, views_only=False):
+    database = introspector.introspect(table_names=tables, views_only=views_only)
 
     print_(TEMPLATE % (
         introspector.get_additional_imports(),
@@ -157,6 +157,8 @@ def get_option_parser():
              'generated file.'))
     ao('-o', '--preserve-order', action='store_true', dest='preserve_order',
        help='Model definition column ordering matches source table.')
+    ao('-v', '--views', action='store_true',
+       help='Get definitions for views instead of tables (Postgres only).')
     return parser
 
 def get_connect_kwargs(options):
@@ -198,4 +200,5 @@ if __name__ == '__main__':
         cmd_line = ' '.join(raw_argv[1:])
         print_header(cmd_line, introspector)
 
-    print_models(introspector, tables, preserve_order=options.preserve_order)
+    print_models(introspector, tables, preserve_order=options.preserve_order,
+            views_only=options.views)


### PR DESCRIPTION
A command line switch will introspect views instead of tables in pwiz.py. A
get_views function was added for Postgres and NotImplemented version for the
interface. It would probably be more convenient for users to do both tables and
views at once, but this was an extremely simple way to do it. I did not add it for
others since I am mostly familiar with Postgres, but it seems pretty easy.