### PR TITLE
Update to Maintain Compatibility

### DIFF
--- a/Update to Maintain Compatibility
+++ b/Update to Maintain Compatibility
@@ -4023,7 +4023,10 @@ class _StringField(Field):
         if isinstance(value, text_type):
             return value
         elif isinstance(value, bytes_type):
-            return value.decode('utf-8')
+            try:
+                return value.decode('utf-8')
+            except UnicodeDecodeError:
+                return value
         return text_type(value)
 
     def __add__(self, other): return self.concat(other)


### PR DESCRIPTION
This change allows compatibility between projects formerly using peewee2.6.2.

When trying to use the latest version of peewee we get the following errors relating to `_StringField`: "Could not get key 'utf-8' codec can't decode byte 0xb4 in position 3" or similar.

Making this change allows easy compatibility.

See issue #262 in neo-python project here: https://github.com/CityOfZion/neo-python/issues/262