### PR TITLE
fix "NameError: name 'hashlib' is not defined"

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -101,6 +101,7 @@ Dropping an index:
 """
 from collections import namedtuple
 import functools
+import hashlib
 import re
 
 from peewee import *

--- a/tests/migrations.py
+++ b/tests/migrations.py
@@ -714,3 +714,16 @@ class TestSchemaMigration(ModelTestCase):
         # Deleting the user will cascade to the associated page.
         User.delete().where(User.id == 'huey').execute()
         self.assertEqual(Page.select().count(), 0)
+
+    def test_make_index_name(self):
+        self.assertEqual(make_index_name('table', ['column']), 'table_column')
+
+    def test_make_index_name_long(self):
+        columns = [
+            'very_long_column_name_number_1',
+            'very_long_column_name_number_2',
+            'very_long_column_name_number_3',
+            'very_long_column_name_number_4'
+        ]
+        name = make_index_name('very_long_table_name', columns)
+        self.assertEqual(len(name), 64)


### PR DESCRIPTION
hashlib is used in playhouse.migrate::make_index_name, but not imported