### PR TITLE
Reflection: Fix broken SQL statement for text-typed default values.

### DIFF
--- a/playhouse/reflection.py
+++ b/playhouse/reflection.py
@@ -19,6 +19,12 @@ try:
 except ImportError:
     postgres_ext = None
 
+import sys
+if sys.version_info[0] == 2:
+    text_type = unicode
+else:
+    text_type = str
+
 RESERVED_WORDS = set([
     'and', 'as', 'assert', 'break', 'class', 'continue', 'def', 'del', 'elif',
     'else', 'except', 'exec', 'finally', 'for', 'from', 'global', 'if',
@@ -81,7 +87,10 @@ class Column(object):
         if self.primary_key and not issubclass(self.field_class, AutoField):
             params['primary_key'] = True
         if self.default is not None:
-            params['constraints'] = '[SQL("DEFAULT %s")]' % self.default
+            if isinstance(self.default, text_type):
+                params['constraints'] = '[SQL("DEFAULT \'%s\'")]' % self.default
+            else:
+                params['constraints'] = '[SQL("DEFAULT %s")]' % self.default
 
         # Handle ForeignKeyField-specific attributes.
         if self.is_foreign_key():


### PR DESCRIPTION
When using the refection module on text-typed (unicode on py2, str on py3) Columns with default values there were parantheses missing around the generated SQL statement. That leads to errors on model migration.

I fixed this error by checking the data type of the default value and adding parantheses around it if it is a text type.
