### PR TITLE
Connect to DB only if not connected already

### DIFF
--- a/playhouse/flask_utils.py
+++ b/playhouse/flask_utils.py
@@ -178,7 +178,8 @@ class FlaskDB(object):
         return self._model_class
 
     def connect_db(self):
-        self.database.connect()
+        if self.database.is_closed():
+            self.database.connect()
 
     def close_db(self, exc):
         if not self.database.is_closed():


### PR DESCRIPTION
When testing Flask apps, failure is "peewee.OperationalError: Connection already opened." I used the same logic inside connect_db as the one used in close_db.