### PR TITLE
Only validate if not backref

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4612,7 +4612,7 @@ class ManyToManyField(MetaField):
                     is_model(through_model)):
                 raise TypeError('Unexpected value for through_model. Expected '
                                 'Model or DeferredThroughModel.')
-            if on_delete is not None or on_update is not None:
+            if not _is_backref and (on_delete is not None or on_update is not None):
                 raise ValueError('Cannot specify on_delete or on_update when '
                                  'through_model is specified.')
         self.rel_model = model


### PR DESCRIPTION
This validation was throwing an exception when creating the backref, because it has a through_model and also receives on_delete and on_update values.

#1719 