### PR TITLE
Fix example/blog time formatting

### DIFF
--- a/examples/blog/templates/detail.html
+++ b/examples/blog/templates/detail.html
@@ -11,6 +11,6 @@
 {% endblock %}
 
 {% block content %}
-  <p>Created {{ entry.timestamp.strftime('%m/%d/%Y at %G:%I%p') }}</p>
+  <p>Created {{ entry.timestamp.strftime('%m/%d/%Y at %I:%M%p') }}</p>
   {{ entry.html_content }}
 {% endblock %}


### PR DESCRIPTION
Just a minor bug found testing your blog example, timestamp was printing `YEAR:HOUR`, fixed it to `HOUR:MIN`