### PR TITLE
Adds support for MySQL SSL connection kwargs

### DIFF
--- a/playhouse/db_url.py
+++ b/playhouse/db_url.py
@@ -110,7 +110,7 @@ def _nest_by_prefix(connect_kwargs, prefix, new_key):
         print connect_kwargs  # {"ssl": {"cert": "foo"}}
     """
     nested = {}
-    for key in connect_kwargs.keys():  # iterate over keys to permit mutation
+    for key in set(connect_kwargs.keys()):  # iterate over copy to mutate
         if key.startswith(prefix):
             nested[key[len(prefix):]] = connect_kwargs.pop(key)
     if nested:

--- a/playhouse/db_url.py
+++ b/playhouse/db_url.py
@@ -74,6 +74,9 @@ def parseresult_to_dict(parsed):
 
         connect_kwargs[key] = value
 
+    if parsed.scheme == "mysql":
+        _nest_by_prefix(connect_kwargs, prefix="ssl_", new_key="ssl")
+
     return connect_kwargs
 
 def parse(url):
@@ -95,6 +98,24 @@ def connect(url, **connect_params):
                                parsed.scheme)
 
     return database_class(**connect_kwargs)
+
+
+def _nest_by_prefix(connect_kwargs, prefix, new_key):
+    """
+    Mutates connect_kwargs
+
+    Example:
+        connect_kwargs = {"ssl_cert": "foo"}
+        _nest_by_prefix(connect_kwargs, prefix="ssl_", new_key="ssl")
+        print connect_kwargs  # {"ssl": {"cert": "foo"}}
+    """
+    nested = {}
+    for key in connect_kwargs.keys():  # iterate over keys to permit mutation
+        if key.startswith(prefix):
+            nested[key[len(prefix):]] = connect_kwargs.pop(key)
+    if nested:
+        connect_kwargs[new_key] = nested
+
 
 # Conditionally register additional databases.
 try:

--- a/tests/db_url.py
+++ b/tests/db_url.py
@@ -29,6 +29,21 @@ class TestDBUrl(BaseTestCase):
         self.assertEqual(cfg['baz'], '3.4.5')
         self.assertEqual(cfg['boolz'], False)
 
+        cfg = parse('mysql://usr:pwd@hst:123/db'
+                    '?foobar=92'
+                    '&ssl_cert=%2Fcerts%2Fcert.pem'
+                    '&ssl_check_hostname=false')
+        self.assertEqual(cfg['user'], 'usr')
+        self.assertEqual(cfg['passwd'], 'pwd')
+        self.assertEqual(cfg['host'], 'hst')
+        self.assertEqual(cfg['database'], 'db')
+        self.assertEqual(cfg['port'], 123)
+        self.assertEqual(cfg["foobar"], 92)
+        self.assertEqual(cfg["ssl"], {
+            "cert": "/certs/cert.pem",
+            "check_hostname": False,
+        })
+
     def test_db_url(self):
         db = connect('sqlite:///:memory:')
         self.assertTrue(isinstance(db, SqliteDatabase))


### PR DESCRIPTION
Addresses https://github.com/coleifer/peewee/issues/1742

To configure SSL connections with MySQL,`MySQLdb.connect` expects a dictionary of SSL params. Currently, `playhouse.db_url`  logic provides no way of parameterizing an SSL connection via the URI. This pull request apes `SQLAlchemy` by letting users specify nested ssl params in the query string with `ssl_*`. 

There should be no backwards compatibility issues, because `ssl_` prefixed query params would've previously had no effect.