### PR TITLE
fix bug group by extend

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1980,8 +1980,8 @@ class Select(SelectBase):
                 grouping.append(column)
         self._group_by = grouping
 
-    @Node.copy
     def group_by_extend(self, *values):
+        """@Node.copy used from group_by() call"""
         group_by = tuple(self._group_by or ()) + values
         return self.group_by(*group_by)
 

--- a/tests/model_sql.py
+++ b/tests/model_sql.py
@@ -78,6 +78,18 @@ class TestModelSQL(ModelDatabaseTestCase):
             'LEFT OUTER JOIN "tweet" AS "t2" ON ("t2"."user_id" = "t1"."id") '
             'GROUP BY "t1"."id", "t1"."username"'), [])
 
+    def test_group_by_extend(self):
+        query = (User
+                 .select(User, fn.COUNT(Tweet.id).alias('tweet_count'))
+                 .join(Tweet, JOIN.LEFT_OUTER)
+                 .group_by_extend(User.id).group_by_extend(User.username))
+        self.assertSQL(query, (
+            'SELECT "t1"."id", "t1"."username", '
+            'COUNT("t2"."id") AS "tweet_count" '
+            'FROM "users" AS "t1" '
+            'LEFT OUTER JOIN "tweet" AS "t2" ON ("t2"."user_id" = "t1"."id") '
+            'GROUP BY "t1"."id", "t1"."username"'), [])
+
     def test_subquery_correction(self):
         users = User.select().where(User.username.in_(['foo', 'bar']))
         query = Tweet.select().where(Tweet.user.in_(users))


### PR DESCRIPTION
I fixed bug group by extend
- Examples:
users table have columns: id and username
Tweet table have contain user_id column. user_id is foreign key of users table

```sql
   query = (User
                 .select(User, fn.COUNT(Tweet.id).alias('tweet_count'))
                 .join(Tweet, JOIN.LEFT_OUTER)
                 .group_by_extend(User.id).group_by_extend(User.username))
```
 
Then I run this query.

- Before I fix bug then result of query :
```sql
SELECT t1.id, t1.username, count(t2.id) as tweet_count
FROM users as t1
LEFT OUTER JOIN tweet as t2 on (t2.user_id = t1.id)
```

-  After I fix bug then result of query:
```sql
SELECT t1.id, t1.username, count(t2.id) as tweet_count
FROM users as t1
LEFT OUTER JOIN tweet as t2 on (t2.user_id = t1.id)
GROUP BY t1.id, t1.username  # I fixed to add group by
```