### PR TITLE
Correct format for PostgreSQL UPDATE statement with FROM clause.

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2150,7 +2150,7 @@ class Update(_WriteQuery):
                 if not isinstance(v, Node):
                     converter = k.db_value if isinstance(k, Field) else None
                     v = Value(v, converter=converter, unpack=False)
-                expressions.append(NodeList((k, SQL('='), v)))
+                expressions.append(NodeList((k, SQL('='), QualifiedNames(v))))
 
             (ctx
              .sql(self.table)
@@ -2162,7 +2162,8 @@ class Update(_WriteQuery):
                     ctx.literal(' FROM ').sql(CommaNodeList(self._from))
 
             if self._where:
-                ctx.literal(' WHERE ').sql(self._where)
+                with ctx.scope_normal():
+                    ctx.literal(' WHERE ').sql(self._where)
             self._apply_ordering(ctx)
             return self.apply_returning(ctx)
 

--- a/tests/expressions.py
+++ b/tests/expressions.py
@@ -80,7 +80,7 @@ class TestValueConversion(ModelTestCase):
                   .update({UpperModel.name: 'zaizee'})
                   .where(UpperModel.id == uid))
         self.assertSQL(update, (
-            'UPDATE "upper_model" SET "name" = UPPER(?) WHERE ("id" = ?)'),
+            'UPDATE "upper_model" SET "name" = UPPER(?) WHERE ("upper_model"."id" = ?)'),
             ['zaizee', uid])
         update.execute()
 

--- a/tests/model_sql.py
+++ b/tests/model_sql.py
@@ -394,16 +394,16 @@ class TestModelSQL(ModelDatabaseTestCase):
                           Stat.timestamp: datetime.datetime(2017, 1, 1)})
                  .where(Stat.url == '/peewee'))
         self.assertSQL(query, (
-            'UPDATE "stat" SET "count" = ("count" + ?), "timestamp" = ? '
-            'WHERE ("url" = ?)'),
+            'UPDATE "stat" SET "count" = ("stat"."count" + ?), "timestamp" = ? '
+            'WHERE ("stat"."url" = ?)'),
             [1, 1483228800, '/peewee'])
 
         query = (Stat
                  .update(count=Stat.count + 1)
                  .where(Stat.url == '/peewee'))
         self.assertSQL(query, (
-            'UPDATE "stat" SET "count" = ("count" + ?) '
-            'WHERE ("url" = ?)'),
+            'UPDATE "stat" SET "count" = ("stat"."count" + ?) '
+            'WHERE ("stat"."url" = ?)'),
             [1, '/peewee'])
 
     def test_update_from(self):
@@ -423,10 +423,10 @@ class TestModelSQL(ModelDatabaseTestCase):
                  .where(Account.sales == SalesPerson.id))
         self.assertSQL(query, (
             'UPDATE "account" SET '
-            '"contact_first" = "first", '
-            '"contact_last" = "last" '
+            '"contact_first" = "t1"."first", '
+            '"contact_last" = "t1"."last" '
             'FROM "sales_person" AS "t1" '
-            'WHERE ("sales_id" = "id")'), [])
+            'WHERE ("account"."sales_id" = "t1"."id")'), [])
 
         query = (User
                  .update({User.username: QualifiedNames(Tweet.content)})
@@ -434,7 +434,7 @@ class TestModelSQL(ModelDatabaseTestCase):
                  .where(Tweet.content == 'tx'))
         self.assertSQL(query, (
             'UPDATE "users" SET "username" = "t1"."content" '
-            'FROM "tweet" AS "t1" WHERE ("content" = ?)'), ['tx'])
+            'FROM "tweet" AS "t1" WHERE ("t1"."content" = ?)'), ['tx'])
 
     def test_update_from_qualnames(self):
         data = [(1, 'u1-x'), (2, 'u2-x')]
@@ -577,7 +577,7 @@ class TestStringsForFieldsa(ModelDatabaseTestCase):
         qliteral = Person.update({'last': 'kitty'}).where(Person.last == 'cat')
         for query in (qkwargs, qliteral):
             self.assertSQL(query, (
-                'UPDATE "person" SET "last" = ? WHERE ("last" = ?)'),
+                'UPDATE "person" SET "last" = ? WHERE ("person"."last" = ?)'),
                 ['kitty', 'cat'])
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1147,7 +1147,7 @@ class TestDeleteInstance(ModelTestCase):
             ('DELETE FROM "favorite" WHERE ("user_id" = ?)', [huey.id]),
             ('DELETE FROM "tweet" WHERE ("user_id" = ?)', [huey.id]),
             ('DELETE FROM "users" WHERE ("id" = ?)', [huey.id]),
-            ('UPDATE "account" SET "user_id" = ? WHERE ("user_id" = ?)',
+            ('UPDATE "account" SET "user_id" = ? WHERE ("account"."user_id" = ?)',
              [None, huey.id]),
         ])
 
@@ -1964,7 +1964,7 @@ class TestReturningIntegration(ModelTestCase):
                  .returning(User.id, User.username))
         self.assertSQL(query, (
             'UPDATE "users" SET "username" = ? '
-            'WHERE ("username" = ?) '
+            'WHERE ("users"."username" = ?) '
             'RETURNING "id", "username"'), ['ziggy', 'zaizee'])
         data = query.execute()
         user = data[0]

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -619,9 +619,9 @@ class TestUpdateQuery(BaseTestCase):
         self.assertSQL(query, (
             'UPDATE "users" SET '
             '"admin" = ?, '
-            '"counter" = ("counter" + ?), '
+            '"counter" = ("users"."counter" + ?), '
             '"username" = ? '
-            'WHERE ("username" = ?)'), [False, 1, 'nuggie', 'nugz'])
+            'WHERE ("users"."username" = ?)'), [False, 1, 'nuggie', 'nugz'])
 
     def test_update_subquery(self):
         count = fn.COUNT(Tweet.c.id).alias('ct')
@@ -639,7 +639,7 @@ class TestUpdateQuery(BaseTestCase):
             'UPDATE "users" SET '
             '"counter" = ?, '
             '"muted" = ? '
-            'WHERE ("id" IN ('
+            'WHERE ("users"."id" IN ('
             'SELECT "users"."id", COUNT("t1"."id") AS "ct" '
             'FROM "users" AS "users" '
             'INNER JOIN "tweets" AS "t1" '
@@ -676,7 +676,7 @@ class TestUpdateQuery(BaseTestCase):
                  .where(User.c.username == 'charlie')
                  .returning(User.c.id))
         self.assertSQL(query, (
-            'UPDATE "users" SET "is_admin" = ? WHERE ("username" = ?) '
+            'UPDATE "users" SET "is_admin" = ? WHERE ("users"."username" = ?) '
             'RETURNING "id"'), [True, 'charlie'])
 
 


### PR DESCRIPTION
Hi,

I tried to use **UPDATE ... FROM** clause using peewee+PostgreSQL without luck. After seeing #1321  I made this patch to fix it.

I'll explain the problem and my solution.


**The Problem**

Consider the following model:

```python
class Race(Model):
    name = CharField()
    gold_bonus = IntegerField()

    class Meta:
        database = db


class Player(Model):
    name = CharField()
    race = ForeignKeyField(Race, backref='players')
    gold = IntegerField(default=0)

    class Meta:
        database = db

if __name__ == '__main__':
    db.connect()
    db.create_tables([Race, Player])

    r1=Race.create(name='Human', gold_bonus=3)
    r2=Race.create(name='Elf', gold_bonus=5)
    p1=Player.create(name='player1', race=r1, gold=0)
    p2=Player.create(name='player2', race=r2, gold=0)
```

I need to perform a query to increment all players *gold* value by the amount of *gold_bonus* of their race plus one.

So I tried:
```python
>>> Player.update(gold=Race.gold_bonus + Player.gold + 1).from_(Race).where(Player.race==Race.id).execute()
Traceback (most recent call last):
  File "/home/nil/.local/share/virtualenvs/miopia-UO75lLMN/lib/python3.6/site-packages/peewee.py", line 2683, in execute_sql
    cursor.execute(sql, params or ())
psycopg2.ProgrammingError: column reference "id" is ambiguous
LINE 1: ... + "gold") + 1) FROM "race" AS "t1" WHERE ("race_id" = "id")
                                                                  ^


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nil/.local/share/virtualenvs/miopia-UO75lLMN/lib/python3.6/site-packages/peewee.py", line 1604, in inner
    return method(self, database, *args, **kwargs)
  File "/home/nil/.local/share/virtualenvs/miopia-UO75lLMN/lib/python3.6/site-packages/peewee.py", line 1675, in execute
    return self._execute(database)
  File "/home/nil/.local/share/virtualenvs/miopia-UO75lLMN/lib/python3.6/site-packages/peewee.py", line 2097, in _execute
    cursor = database.execute(self)
  File "/home/nil/.local/share/virtualenvs/miopia-UO75lLMN/lib/python3.6/site-packages/peewee.py", line 2696, in execute
    return self.execute_sql(sql, params, commit=commit)
  File "/home/nil/.local/share/virtualenvs/miopia-UO75lLMN/lib/python3.6/site-packages/peewee.py", line 2690, in execute_sql
    self.commit()
  File "/home/nil/.local/share/virtualenvs/miopia-UO75lLMN/lib/python3.6/site-packages/peewee.py", line 2481, in __exit__
    reraise(new_type, new_type(*exc_args), traceback)
  File "/home/nil/.local/share/virtualenvs/miopia-UO75lLMN/lib/python3.6/site-packages/peewee.py", line 178, in reraise
    raise value.with_traceback(tb)
  File "/home/nil/.local/share/virtualenvs/miopia-UO75lLMN/lib/python3.6/site-packages/peewee.py", line 2683, in execute_sql
    cursor.execute(sql, params or ())
peewee.ProgrammingError: column reference "id" is ambiguous
LINE 1: ... + "gold") + 1) FROM "race" AS "t1" WHERE ("race_id" = "id")
                                                                  ^
```

The problem is with the generated query:

```sql
UPDATE
    "player"
SET
    "gold" = (("gold_bonus" + "gold") + 1)
FROM
    "race" AS "t1"
WHERE 
    ("race_id" = "id")
```

As you can see, the term **id** is ambiguous as it appears in both *player* and *race* tables.

A correct version of the query should look something like:

```sql
UPDATE
    "player"
SET
    "gold" = (("t1"."gold_bonus" + "player"."gold") + 1)
FROM
    "race" AS "t1"
WHERE
    ("player"."race_id" = "t1"."id")
```

Note in the *SET* portion of the query, the left hand side of the assignment is not fully-qualified (because you can only assign to fields in the *UPDATE* table) while the right hand side of the assignment is fully-qualified.


**The Patch**

1. I modified the for loop in the \_\_sql\_\_ method of the Update class to use *QualifiedNames()* just for the right hand side of the assignments.
2. In the same method, I modified the part where the **WHERE** is added surrounding it with *ctx.scope_normal*. I don't know if I am using the correct scope, but it yields the desired behavior.
3. I rewrote the part of the tests where static *UPDATE* queries are checked against the implementation, using the new rules for the SET and WHERE part.

I run the test suit against:

- Sqlite: No errors
- Postgres: Some warnings because my installation lacks hstore.
- MySQL: Some errors and failed tests but appears unrelated to this patch.

Please let me know what you think about the patch or any changes/improvements you want me to include.

Cheers!
 