### PR TITLE
PostgreSQL UPDATE statement with FROM clause with subquery support

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2150,7 +2150,7 @@ class Update(_WriteQuery):
                 if not isinstance(v, Node):
                     converter = k.db_value if isinstance(k, Field) else None
                     v = Value(v, converter=converter, unpack=False)
-                expressions.append(NodeList((k, SQL('='), v)))
+                expressions.append(NodeList((k, SQL('='), QualifiedNames(v))))
 
             (ctx
              .sql(self.table)

--- a/tests/model_sql.py
+++ b/tests/model_sql.py
@@ -394,7 +394,7 @@ class TestModelSQL(ModelDatabaseTestCase):
                           Stat.timestamp: datetime.datetime(2017, 1, 1)})
                  .where(Stat.url == '/peewee'))
         self.assertSQL(query, (
-            'UPDATE "stat" SET "count" = ("count" + ?), "timestamp" = ? '
+            'UPDATE "stat" SET "count" = ("stat"."count" + ?), "timestamp" = ? '
             'WHERE ("stat"."url" = ?)'),
             [1, 1483228800, '/peewee'])
 
@@ -402,7 +402,7 @@ class TestModelSQL(ModelDatabaseTestCase):
                  .update(count=Stat.count + 1)
                  .where(Stat.url == '/peewee'))
         self.assertSQL(query, (
-            'UPDATE "stat" SET "count" = ("count" + ?) '
+            'UPDATE "stat" SET "count" = ("stat"."count" + ?) '
             'WHERE ("stat"."url" = ?)'),
             [1, '/peewee'])
 
@@ -423,8 +423,8 @@ class TestModelSQL(ModelDatabaseTestCase):
                  .where(Account.sales == SalesPerson.id))
         self.assertSQL(query, (
             'UPDATE "account" SET '
-            '"contact_first" = "first", '
-            '"contact_last" = "last" '
+            '"contact_first" = "t1"."first", '
+            '"contact_last" = "t1"."last" '
             'FROM "sales_person" AS "t1" '
             'WHERE ("account"."sales_id" = "t1"."id")'), [])
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -619,7 +619,7 @@ class TestUpdateQuery(BaseTestCase):
         self.assertSQL(query, (
             'UPDATE "users" SET '
             '"admin" = ?, '
-            '"counter" = ("counter" + ?), '
+            '"counter" = ("users"."counter" + ?), '
             '"username" = ? '
             'WHERE ("users"."username" = ?)'), [False, 1, 'nuggie', 'nugz'])
 


### PR DESCRIPTION
This is a second try on #1775 , because the request was accepted and then reverted I am opening this.

The changes with master are:

1. I reverted the SET part in the UPDATE test queries.
2. I wrote a helper function to recursively qualify only ColumnBase member of Expressions.
3. I applied this helper to the RHS of the assignments in the SET part of UPDATE queries.

All tests, including the new regressions tests appear to be passing now.

Let me know what you think.