### PR TITLE
rollback only if connection is not closed

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2827,7 +2827,8 @@ class Database(_callable_context_manager):
         return self._state.conn.commit()
 
     def rollback(self):
-        return self._state.conn.rollback()
+        if not self.is_closed():
+            return self._state.conn.rollback()
 
     def batch_commit(self, it, n):
         for group in chunked(it, n):


### PR DESCRIPTION
this fix prevent next error
```
  File "contrib/python/peewee/peewee.py", line 5952, in __iter__
    self.execute()
  File "contrib/python/peewee/peewee.py", line 1604, in inner
    return method(self, database, *args, **kwargs)
  File "contrib/python/peewee/peewee.py", line 1675, in execute
    return self._execute(database)
  File "contrib/python/peewee/peewee.py", line 1826, in _execute
    cursor = database.execute(self)
  File "contrib/python/peewee/peewee.py", line 2696, in execute
    return self.execute_sql(sql, params, commit=commit)
  File "contrib/python/peewee/peewee.py", line 2690, in execute_sql
    self.commit()
  File "contrib/python/peewee/peewee.py", line 2481, in __exit__
    reraise(new_type, new_type(*exc_args), traceback)
  File "contrib/python/peewee/peewee.py", line 2686, in execute_sql
    self.rollback()
  File "contrib/python/peewee/peewee.py", line 2805, in rollback
    return self._state.conn.rollback()
InterfaceError: connection already closed
```