### PR TITLE
Fixed deprecation warning for importing Callable ABC's from collections

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -21,9 +21,9 @@ import time
 import uuid
 import warnings
 try:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Callable
 except ImportError:
-    from collections import Mapping
+    from collections import Mapping, Callable
 
 try:
     from pysqlite3 import dbapi2 as pysq3
@@ -155,6 +155,7 @@ except ImportError:
             return path[0].join(quote_chars)
         return '.'.join([part.join(quote_chars) for part in path])
 
+callable_ = lambda c: isinstance(c, Callable)
 
 if sys.version_info[0] == 2:
     text_type = unicode
@@ -167,9 +168,7 @@ if sys.version_info[0] == 2:
         sys.stdout.write('\n')
 else:
     import builtins
-    from collections import Callable
     from functools import reduce
-    callable = lambda c: isinstance(c, Callable)
     text_type = str
     bytes_type = bytes
     buffer_type = memoryview
@@ -2288,7 +2287,7 @@ class Insert(_WriteQuery):
                 except (KeyError, IndexError):
                     if column in defaults:
                         val = defaults[column]
-                        if callable(val):
+                        if callable_(val):
                             val = val()
                     else:
                         raise ValueError('Missing value for "%s".' % column)
@@ -4557,7 +4556,7 @@ class ForeignKeyField(Field):
         # calling declared_backref() (if callable).
         super(ForeignKeyField, self).bind(model, name, set_attribute)
 
-        if callable(self.declared_backref):
+        if callable_(self.declared_backref):
             self.backref = self.declared_backref(self)
         else:
             self.backref, self.declared_backref = self.declared_backref, None
@@ -5218,7 +5217,7 @@ class Metadata(object):
             if field.default is not None:
                 # This optimization helps speed up model instance construction.
                 self.defaults[field] = field.default
-                if callable(field.default):
+                if callable_(field.default):
                     self._default_callables[field] = field.default
                     self._default_callable_list.append((field.name,
                                                         field.default))

--- a/playhouse/shortcuts.py
+++ b/playhouse/shortcuts.py
@@ -1,7 +1,6 @@
 import sys
 
-from peewee import *
-from peewee import Alias
+from peewee import Alias, Field, ForeignKeyField
 
 if sys.version_info[0] == 3:
     from collections import Callable

--- a/playhouse/shortcuts.py
+++ b/playhouse/shortcuts.py
@@ -1,11 +1,4 @@
-import sys
-
-from peewee import Alias, Field, ForeignKeyField
-
-if sys.version_info[0] == 3:
-    from collections import Callable
-    callable = lambda c: isinstance(c, Callable)
-
+from peewee import Alias, Field, ForeignKeyField, callable_
 
 _clone_set = lambda s: set(s) if s else set()
 
@@ -94,7 +87,7 @@ def model_to_dict(model, recurse=True, backrefs=False, only=None,
     if extra_attrs:
         for attr_name in extra_attrs:
             attr = getattr(model, attr_name)
-            if callable(attr):
+            if callable_(attr):
                 data[attr_name] = attr()
             else:
                 data[attr_name] = attr


### PR DESCRIPTION
to avoid:

```bash
.../peewee.py:169: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Callable
```