### PR TITLE
In an expression, don't use left hand side's converter if right hand side's is a function

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1278,7 +1278,7 @@ class Expression(ColumnBase):
 
     def __sql__(self, ctx):
         overrides = {'parentheses': not self.flat}
-        if isinstance(self.lhs, Field):
+        if isinstance(self.lhs, Field) and not isinstance(self.rhs, Function):
             overrides['converter'] = self.lhs.db_value
         else:
             overrides['converter'] = None

--- a/tests/expressions.py
+++ b/tests/expressions.py
@@ -131,6 +131,13 @@ class TestValueConversion(ModelTestCase):
             'WHERE ("t1"."name" = ?)'), ['huey'])
         self.assertRaises(UpperModel.DoesNotExist, sq.get)
 
+        # If the value was inside a function, the conversion is not applied
+        sq = UpperModel.select().where(UpperModel.name == fn.LOWER('huey'))
+        self.assertSQL(sq, (
+            'SELECT "t1"."id", "t1"."name" FROM "upper_model" AS "t1" '
+            'WHERE ("t1"."name" = LOWER(?))'), ['huey'])
+        self.assertRaises(UpperModel.DoesNotExist, sq.get)
+
     def test_value_conversion_query(self):
         um = UpperModel.create(name='huey')
         UM = UpperModel.alias()


### PR DESCRIPTION
Should fix #1791 