### PR TITLE
setdefault added to playhouse kv, for dict like setdefault behavior

### DIFF
--- a/playhouse/kv.py
+++ b/playhouse/kv.py
@@ -140,6 +140,13 @@ class KeyValue(object):
         except KeyError:
             return default
 
+    def setdefault(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            self[key] = default
+            return default
+
     def pop(self, key, default=Sentinel):
         with self._database.atomic():
             try:

--- a/tests/kv.py
+++ b/tests/kv.py
@@ -57,6 +57,11 @@ class TestKeyValue(DatabaseTestCase):
         self.assertTrue(KV.get('kx') is None)
         self.assertEqual(KV.get('kx', 'vx'), 'vx')
 
+        self.assertTrue(KV.get('k4') is None)
+        self.assertEqual(KV.setdefault('k4', 'v4'), 'v4')
+        self.assertEqual(KV.get('k4'), 'v4')
+        self.assertEqual(KV.get('k4', 'v5'),  'v4')
+
         KV.clear()
         self.assertEqual(len(KV), 0)
 


### PR DESCRIPTION
To make KeyValue behave more like the regular python dict, a setdefault is also added.
This is a feature that we regularly use in our team when the db isn't initialized with any value, especially for settings and config items.