### PR TITLE
Removed incorrect import. ManyToManyField is in peewee module

### DIFF
--- a/docs/peewee/relationships.rst
+++ b/docs/peewee/relationships.rst
@@ -806,8 +806,7 @@ Modeling students and courses using :py:class:`ManyToManyField`:
 .. code-block:: python
 
     from peewee import *
-    from playhouse.fields import ManyToManyField
-
+    
     db = SqliteDatabase('school.db')
 
     class BaseModel(Model):


### PR DESCRIPTION
Sorry, this line in the docs has been bugging me for years. It's been a while since ManyToManyField has been moved to the peewee core and is not located in the playhouse module anymore.