### PR TITLE
Travis CI recommends removing the sudo tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
         - ./.travis_deps.sh
         - sudo ldconfig
       script: "python runtests.py -v2"
+  allow_failures:
+    - python: 3.8-dev
 addons:
   postgresql: "9.6"
   mariadb: "10.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - 3.4
   - 3.5
   - 3.6
-dist: trusty
 env:
   - PEEWEE_TEST_BACKEND=sqlite
   - PEEWEE_TEST_BACKEND=postgresql
@@ -13,22 +12,17 @@ matrix:
   include:
     - python: 3.7
       dist: xenial
-      sudo: true
       env: PEEWEE_TEST_BACKEND=sqlite
     - python: 3.7
       dist: xenial
-      sudo: true
       env: PEEWEE_TEST_BACKEND=postgresql
     - python: 3.7
       dist: xenial
-      sudo: true
       env: PEEWEE_TEST_BACKEND=mysql
     - python: 3.8-dev
       dist: xenial
-      sudo: true
     - python: 3.7
       dist: xenial
-      sudo: true
       env:
       - PEEWEE_TEST_BUILD_SQLITE=1
       - PEEWEE_CLOSURE_EXTENSION=/usr/local/lib/closure.so


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"