### PR TITLE
Add support for Postgres's plainto_tsquery

### DIFF
--- a/docs/peewee/playhouse.rst
+++ b/docs/peewee/playhouse.rst
@@ -1042,6 +1042,14 @@ inserting or updating the ``search_content`` field:
 
 .. note:: If you are using the :py:class:`TSVectorField`, it will automatically be created with a GIN index.
 
+To search a ``tsvector`` field, you can use its match method:
+
+.. code-block:: python
+
+    query = Blog.select().where(cls.search_content.match(query, "peewee"))
+
+Alternatively, you can use Postgres's more permissive ``plainto_tsquery`` by passing ``use_plain=True``.
+
 
 postgres_ext API notes
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/playhouse/postgres_ext.py
+++ b/playhouse/postgres_ext.py
@@ -343,9 +343,14 @@ class TSVectorField(IndexedFieldMixin, TextField):
     field_type = 'TSVECTOR'
     __hash__ = Field.__hash__
 
-    def match(self, query, language=None):
+    def match(self, query, language=None, use_plain=False):
         params = (language, query) if language is not None else (query,)
-        return Expression(self, TS_MATCH, fn.to_tsquery(*params))
+        if use_plain:
+            q = fn.plainto_tsquery(*params)
+        else:
+            q = fn.to_tsquery(*params)
+
+        return Expression(self, TS_MATCH, q)
 
 
 def Match(field, query, language=None):


### PR DESCRIPTION
peewee's `TSVectorField` helpfully includes a `match` method to add a `tsquery` to a query using `to_tsquery`. However, `to_tsquery` is one of two ways you can convert a string to a `tsquery`, per the [Postgres docs](https://www.postgresql.org/docs/9.1/textsearch-controls.html):

> PostgreSQL provides the functions to_tsquery and plainto_tsquery for converting a query to the tsquery data type. to_tsquery offers access to more features than plainto_tsquery, but is less forgiving about its input.

This pull request adds a `use_plain` parameter to `TSVectorField.match`, thus letting the programmer choose whether to use `to_tsquery` or `plainto_tsquery`. That's especially helpful when you're writing an application with casual user input for a search query.