### PR TITLE
Make sure pwiz take care of camelCase

### DIFF
--- a/pwiz.py
+++ b/pwiz.py
@@ -49,7 +49,7 @@ def make_introspector(database_type, database_name, **kwargs):
     return Introspector.from_database(db, schema=schema)
 
 def print_models(introspector, tables=None, preserve_order=False,
-                 include_views=False, ignore_unknown=False, camel_to_snake=False):
+                 include_views=False, ignore_unknown=False, camel_to_snake=True):
     database = introspector.introspect(table_names=tables,
                                        include_views=include_views,
                                        camel_to_snake=camel_to_snake)
@@ -181,8 +181,8 @@ def get_option_parser():
        help='Model definition column ordering matches source table.')
     ao('-I', '--ignore-unknown', action='store_true', dest='ignore_unknown',
        help='Ignore fields whose type cannot be determined.')
-    ao('-S', '--snake', action='store_true', dest='camel_to_snake',
-       help='Convert camelCase to snake_case')
+    ao('-S', '--snake', dest='camel_to_snake', type='int',
+       default=1, help='Whether convert camelCase to snake_case, 0 for no, 1 for yes')
     return parser
 
 def get_connect_kwargs(options):
@@ -218,4 +218,4 @@ if __name__ == '__main__':
         print_header(cmd_line, introspector)
 
     print_models(introspector, tables, options.preserve_order, options.views,
-                 options.ignore_unknown, options.camel_to_snake)
+                 options.ignore_unknown, bool(options.camel_to_snake))

--- a/pwiz.py
+++ b/pwiz.py
@@ -49,10 +49,10 @@ def make_introspector(database_type, database_name, **kwargs):
     return Introspector.from_database(db, schema=schema)
 
 def print_models(introspector, tables=None, preserve_order=False,
-                 include_views=False, ignore_unknown=False):
+                 include_views=False, ignore_unknown=False, camel_to_snake=False):
     database = introspector.introspect(table_names=tables,
                                        include_views=include_views,
-                                       camel_to_snake=True)
+                                       camel_to_snake=camel_to_snake)
 
     db_kwargs = introspector.get_database_kwargs()
     header = HEADER % (
@@ -181,6 +181,8 @@ def get_option_parser():
        help='Model definition column ordering matches source table.')
     ao('-I', '--ignore-unknown', action='store_true', dest='ignore_unknown',
        help='Ignore fields whose type cannot be determined.')
+    ao('-S', '--snake', action='store_true', dest='camel_to_snake',
+       help='Convert camelCase to snake_case')
     return parser
 
 def get_connect_kwargs(options):
@@ -216,4 +218,4 @@ if __name__ == '__main__':
         print_header(cmd_line, introspector)
 
     print_models(introspector, tables, options.preserve_order, options.views,
-                 options.ignore_unknown)
+                 options.ignore_unknown, options.camel_to_snake)

--- a/pwiz.py
+++ b/pwiz.py
@@ -51,7 +51,8 @@ def make_introspector(database_type, database_name, **kwargs):
 def print_models(introspector, tables=None, preserve_order=False,
                  include_views=False, ignore_unknown=False):
     database = introspector.introspect(table_names=tables,
-                                       include_views=include_views)
+                                       include_views=include_views,
+                                       camel_to_snake=True)
 
     db_kwargs = introspector.get_database_kwargs()
     header = HEADER % (

--- a/tests/pwiz_integration.py
+++ b/tests/pwiz_integration.py
@@ -46,11 +46,19 @@ class Category(TestModel):
 class OddColumnNames(TestModel):
     spaces = CharField(column_name='s p aces')
     symbols = CharField(column_name='w/-nug!')
+    camelCase = CharField(column_name='camelCase')
 
 
 class Event(TestModel):
     data = TextField()
     status = IntegerField()
+
+
+class CamelCaseTableName(TestModel):
+    camelCase = CharField(column_name='camelCase')
+
+    class Meta:
+        table_name = "camelCaseTableName"
 
 
 class capture_output(object):
@@ -75,6 +83,12 @@ class UnknownField(object):
 class BaseModel(Model):
     class Meta:
         database = database
+
+class CamelCaseTableName(BaseModel):
+    camel_case = CharField(column_name='camelCase')
+
+    class Meta:
+        table_name = 'camelCaseTableName'
 
 class Category(BaseModel):
     name = CharField(unique=True)
@@ -153,7 +167,7 @@ class BasePwizTestCase(ModelTestCase):
 
 
 class TestPwiz(BasePwizTestCase):
-    requires = [User, Note, Category]
+    requires = [User, CamelCaseTableName, Note, Category]
 
     def test_print_models(self):
         with capture_output() as output:
@@ -235,6 +249,7 @@ class TestPwizInvalidColumns(BasePwizTestCase):
         result = output.data.strip()
         expected = textwrap.dedent("""
             class OddColumnNames(BaseModel):
+                camel_case = CharField(column_name='camelCase')
                 s_p_aces = CharField(column_name='s p aces')
                 w_nug_ = CharField(column_name='w/-nug!')
 


### PR DESCRIPTION
Add feature/testcases so that if original table/column name is camelCase the autogenerated one by pwiz will be snake_case


Let's say we have a table named `CamelCaseTableName` who has a column named `camelCase`, with `pwiz`,
## Before
```python
class Camelcasetablename(BaseModel):
    camelcase = CharField(column_name='camelCase')

    class Meta:
        table_name = 'camelCaseTableName'
```

## After
```python
class CamelCaseTableName(BaseModel):
    camel_case = CharField(column_name='camelCase')

    class Meta:
        table_name = 'camelCaseTableName'
```