### PR TITLE
Add note to quickstart about deferring database initialization

### DIFF
--- a/docs/peewee/quickstart.rst
+++ b/docs/peewee/quickstart.rst
@@ -51,6 +51,12 @@ data model, by defining one or more :py:class:`Model` classes:
             database = db # This model uses the "people.db" database.
 
 .. note::
+    If you want your database file path to be based on the environment (e.g.
+    ``XDG_DATA_HOME``) or a configuration setting, you can defer the
+    initialization of the database by specifying ``None`` as the database name.
+    Refer to the :ref:`deferring_initialization` section for more details.
+
+.. note::
     Peewee will automatically infer the database table name from the name of
     the class. You can override the default name by specifying a ``table_name``
     attribute in the inner "Meta" class (alongside the ``database`` attribute).


### PR DESCRIPTION
I'm new to peewee, and must admit I spent way too much time trying to figure out how to make my application use a temporary database during tests.  I'm generating the database path with [appdirs](https://github.com/ActiveState/appdirs) and changing the environment during tests with [pytest's monkeypatch](https://docs.pytest.org/en/latest/reference.html#_pytest.monkeypatch.MonkeyPatch.setenv).  Run-time database configuration was exactly what I needed, I just didn't know to search for that term.  Eventually I found the documentation for that, but I think it's important enough to make note of it in the quickstart.