### PR TITLE
Replace deprecated PrimaryKeyField with AutoField in docs

### DIFF
--- a/docs/peewee/models.rst
+++ b/docs/peewee/models.rst
@@ -743,11 +743,11 @@ relationships, and more).
 .. code-block:: pycon
 
     >>> Person._meta.fields
-    {'id': <peewee.PrimaryKeyField object at 0x7f51a2e92750>,
+    {'id': <peewee.AutoField object at 0x7f51a2e92750>,
      'name': <peewee.CharField object at 0x7f51a2f0a510>}
 
     >>> Person._meta.primary_key
-    <peewee.PrimaryKeyField object at 0x7f51a2e92750>
+    <peewee.AutoField object at 0x7f51a2e92750>
 
     >>> Person._meta.database
     <peewee.SqliteDatabase object at 0x7f519bff6dd0>
@@ -1216,7 +1216,7 @@ to use the :py:meth:`Model.insert_many` API:
         User.insert_many(data, fields=fields).execute()
 
 If you *always* want to have control over the primary key, simply do not use
-the :py:class:`PrimaryKeyField` field type, but use a normal
+the :py:class:`AutoField` field type, but use a normal
 :py:class:`IntegerField` (or other column type):
 
 .. code-block:: python


### PR DESCRIPTION
<details>
<summary>Grep after change</summary>

    > rg -i 'PrimaryKeyField'
    CHANGELOG.md
    885:Re-add a shim for `PrimaryKeyField` (renamed to `AutoField`) and log a
    
    tests/fields.py
    450:class TestCompositePrimaryKeyField(ModelTestCase):
    
    peewee.py
    124:    'PrimaryKeyField',  # XXX: Deprecated, change to AutoField.
    4346:class PrimaryKeyField(AutoField):
    4348:        __deprecated__('"PrimaryKeyField" has been renamed to "AutoField". '
    4351:        super(PrimaryKeyField, self).__init__(*args, **kwargs)
    
    docs/peewee/changes.rst
    56:* :py:class:`PrimaryKeyField` has been renamed to :py:class:`AutoField`

</details>