### PR TITLE
Fix empty bulk_create error

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -5996,6 +5996,8 @@ class Model(with_metaclass(ModelBase, Node)):
 
     @classmethod
     def bulk_create(cls, model_list, batch_size=None):
+        if len(model_list) == 0:
+            return
         if batch_size is not None:
             batches = chunked(model_list, batch_size)
         else:

--- a/tests/models.py
+++ b/tests/models.py
@@ -171,6 +171,12 @@ class TestModelAPIs(ModelTestCase):
                              [user.id for user in users])
 
     @requires_models(User)
+    def test_empty_bulk_create(self):
+        self.assertEqual(User.select().count(), 0)
+        User.bulk_create([])
+        self.assertEqual(User.select().count(), 0)
+
+    @requires_models(User)
     def test_bulk_create_batching(self):
         users = [User(username=str(i)) for i in range(10)]
         with self.assertQueryCount(4):


### PR DESCRIPTION
I noticed that attempt to insert an empty bulk to database (sqlite in my case) is causing following error:
```
Traceback (most recent call last):
  File "/home/vicrac/peewee/peewee.py", line 2946, in execute_sql
    cursor.execute(sql, params or ())
sqlite3.OperationalError: incomplete input

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vicrac/peewee/tests/base.py", line 240, in inner
    method(self)
  File "/home/vicrac/peewee/tests/models.py", line 176, in test_empty_bulk_create
    User.bulk_create([])
  File "/home/vicrac/peewee/peewee.py", line 6016, in bulk_create
    res = cls.insert_many(accum, fields=fields).execute()
  File "/home/vicrac/peewee/peewee.py", line 1785, in inner
    return method(self, database, *args, **kwargs)
  File "/home/vicrac/peewee/peewee.py", line 1856, in execute
    return self._execute(database)
  File "/home/vicrac/peewee/peewee.py", line 2571, in _execute
    return super(Insert, self)._execute(database)
  File "/home/vicrac/peewee/peewee.py", line 2320, in _execute
    cursor = database.execute(self)
  File "/home/vicrac/peewee/peewee.py", line 2959, in execute
    return self.execute_sql(sql, params, commit=commit)
  File "/home/vicrac/peewee/peewee.py", line 2953, in execute_sql
    self.commit()
  File "/home/vicrac/peewee/peewee.py", line 2729, in __exit__
    reraise(new_type, new_type(*exc_args), traceback)
  File "/home/vicrac/peewee/peewee.py", line 183, in reraise
    raise value.with_traceback(tb)
  File "/home/vicrac/peewee/peewee.py", line 2946, in execute_sql
    cursor.execute(sql, params or ())
peewee.OperationalError: incomplete input
```
It took me some time to figure it out, so I fixed it the simplest possible way - return from method if list is empty. I added also a simple test for it (which currently passess).