### PR TITLE
replace instance delete method with model delete method

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -6245,7 +6245,7 @@ class Model(with_metaclass(ModelBase, Node)):
                     model.update(**{fk.name: None}).where(query).execute()
                 else:
                     model.delete().where(query).execute()
-        return self.delete().where(self._pk_expr()).execute()
+        return Model.delete().where(self._pk_expr()).execute()
 
     def __hash__(self):
         return hash((self.__class__, self._pk))


### PR DESCRIPTION
The pitfalls of `delete` method in instance are numerous. It may cause unintended consequences, such as truncating table.

I want to disable `delete` method call and raise warning in instance. After reading the code, I found that `delete_instance` use `delete` to do the actual dirty work in instance. Because of this, disabling `delete` method is difficult without changing `delete_instance` method. I have to copy `delete_instance` 's code and fix it to workaround this.

If code is changed as below, we can still call `delete` method in Model Object without any change, and call `delete_instance` method in Model's instance correctly, and at the same time, we can override `delete` method in instance to disable usage in instance for avoiding unexpected consequences.