### PR TITLE
Support raising custom DoesNotExist exceptions in models

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -5857,9 +5857,16 @@ class ModelBase(type):
             setattr(cls, '__repr__', lambda self: '<%s: %s>' % (
                 cls.__name__, self.__str__()))
 
-        exc_name = '%sDoesNotExist' % cls.__name__
-        exc_attrs = {'__module__': cls.__module__}
-        exception_class = type(exc_name, (DoesNotExist,), exc_attrs)
+        if not hasattr(cls, 'DoesNotExist'):
+            exc_name = '%sDoesNotExist' % cls.__name__
+            exc_attrs = {'__module__': cls.__module__}
+            exception_class = type(exc_name, (DoesNotExist,), exc_attrs)
+        else:
+            if not issubclass(cls.DoesNotExist, DoesNotExist):
+                raise ValueError('%s must inherit from peewee.DoesNotExist'
+                                 % cls.DoesNotExist)
+
+            exception_class = cls.DoesNotExist
         cls.DoesNotExist = exception_class
 
         # Call validation hook, allowing additional model validation.

--- a/tests/models.py
+++ b/tests/models.py
@@ -37,9 +37,15 @@ if sys.version_info[0] >= 3:
     long = int
 
 
+class UnknownColorException(DoesNotExist):
+    pass
+
+
 class Color(TestModel):
     name = CharField(primary_key=True)
     is_neutral = BooleanField(default=False)
+
+    DoesNotExist = UnknownColorException
 
 
 class Post(TestModel):
@@ -389,6 +395,12 @@ class TestModelAPIs(ModelTestCase):
         tweet = Tweet.get(content__ilike='w%',
                           user__username__ilike='%ck%')
         self.assertEqual(tweet.content, 'woof')
+
+    @requires_models(Color)
+    def test_custom_does_not_exist_exception(self):
+        self.assertRaises(DoesNotExist, Color.get_by_id, 'pizza')
+        self.assertRaises(Color.DoesNotExist, Color.get_by_id, 'pizza')
+        self.assertRaises(UnknownColorException, Color.get_by_id, 'pizza')
 
     @requires_models(User)
     def test_get_with_alias(self):


### PR DESCRIPTION
### Why do we need this?

- The current way of raising a custom `DoesNotExist` exception is to override model methods like `.get_by_id()`, catch `DoesNotExist` and re-raise with a custom exception class. This is too much boilerplate for something that should be doable with something like:

    ```py
    class BaseModel(Model):
        DoesNotExist = MyCustomException
    ```
- Django ORM supports it, and so do most other ORMs.