### PR TITLE
Avoid situations where connections have same ts.

### DIFF
--- a/playhouse/pool.py
+++ b/playhouse/pool.py
@@ -33,6 +33,7 @@ That's it!
 """
 import heapq
 import logging
+import random
 import time
 from collections import namedtuple
 from itertools import chain
@@ -153,7 +154,7 @@ class PooledDatabase(object):
                     len(self._in_use) >= self._max_connections):
                 raise MaxConnectionsExceeded('Exceeded maximum connections.')
             conn = super(PooledDatabase, self)._connect()
-            ts = time.time()
+            ts = time.time() + random.random() / 1000 # alterate ts to avoid situations where connections have same ts
             key = self.conn_key(conn)
             logger.debug('Created new connection %s.', key)
 


### PR DESCRIPTION
Hello,
I was able to reproduce the bug from this issue: https://github.com/coleifer/peewee/issues/1883
Adding a small random number to ts, avoids that race condition.