### PR TITLE
Fix bug with multiple model prefetches

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -7439,7 +7439,7 @@ def prefetch(sq, *subqueries):
                 rel_map.setdefault(rel_model, [])
                 rel_map[rel_model].append(pq)
 
-        deps[query_model] = {}
+        deps.setdefault(query_model, {})
         id_map = deps[query_model]
         has_relations = bool(rel_map.get(query_model))
 


### PR DESCRIPTION
I found when calling prefetch with a model multiple times but on different rel models would result in only one of the rel models getting the instances populated and all others with empty lists. This changes seems to fix the issue.