### PR TITLE
Add ability to update JSON fields that are lists in Model.bulk_update

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -4184,13 +4184,17 @@ Model
               :py:meth:`Database.atomic`. Otherwise an error in a batch mid-way
               through could leave the database in an inconsistent state.
 
-    .. py:classmethod:: bulk_update(model_list, fields[, batch_size=None])
+    .. py:classmethod:: bulk_update(model_list, fields[[, batch_size=None], unpack_values=True])
 
         :param iterable model_list: a list or other iterable of
             :py:class:`Model` instances.
         :param list fields: list of fields to update.
         :param int batch_size: number of rows to batch per insert. If
             unspecified, all models will be inserted in a single query.
+        :param bool unpack_values: whether to unpack iterable values
+            into multiple values. Passed as `unpack` parameter to 
+            ``Value``. Useful when updating e.g. ``JSONField`` that is
+            a top-level list object.
         :returns: total number of rows updated.
 
         Efficiently UPDATE multiple model instances.

--- a/peewee.py
+++ b/peewee.py
@@ -6218,7 +6218,7 @@ class Model(with_metaclass(ModelBase, Node)):
                     setattr(model, pk_name, obj_id)
 
     @classmethod
-    def bulk_update(cls, model_list, fields, batch_size=None):
+    def bulk_update(cls, model_list, fields, batch_size=None, unpack_values=True):
         if isinstance(cls._meta.primary_key, CompositeKey):
             raise ValueError('bulk_update() is not supported for models with '
                              'a composite primary key.')
@@ -6244,7 +6244,7 @@ class Model(with_metaclass(ModelBase, Node)):
                 for model in batch:
                     value = getattr(model, attr)
                     if not isinstance(value, Node):
-                        value = Value(value, converter=field.db_value)
+                        value = Value(value, converter=field.db_value, unpack=unpack_values)
                     accum.append((model._pk, value))
                 case = Case(cls._meta.primary_key, accum)
                 update[field] = case

--- a/tests/sqlite.py
+++ b/tests/sqlite.py
@@ -458,6 +458,20 @@ class TestJSONField(ModelTestCase):
         kd2_db = KeyData.get(KeyData.key == 'k2')
         self.assertEqual(kd2_db.data, {'k1': 'v1', 'k2': 'v2'})
 
+    def test_json_bulk_update_top_level_list(self):
+        kd1 = KeyData.create(key='k1', data=['a', 'b', 'c'])
+        kd2 = KeyData.create(key='k2', data=['e', 'f', 'g'])
+
+        #update with top-level lists
+        kd1.data = ['h', 'i', 'j']
+        kd2.data = ['k', 'l', 'm']
+
+        #don't unpack values as they are list objects that we want to update
+        KeyData.bulk_update([kd1, kd2], fields=[KeyData.data], unpack_values=False)
+        kd1_db = KeyData.get(KeyData.key == 'kd1')
+        kd2_db = KeyData.get(KeyData.key == 'kd2')
+        self.assertEqual(kd1_db.data, ['h', 'i', 'j'])
+        self.assertEqual(kd2_db.data, ['k', 'l', 'm'])
 
 @skip_unless(json_installed(), 'requires sqlite json1')
 class TestJSONFieldFunctions(ModelTestCase):


### PR DESCRIPTION
I noticed that using `Model.bulk_update` won't work with `JSONField`s that are top-level lists because by default `Value` will unpack the list into multiple values. Top-level lists are valid JSON objects.

Example (before):
```python
class Item(Model):
    json = JSONField()

item = Item.create(json=['a','b'])
item.json = ['c','d']

Item.bulk_update([item], fields=[Item.json])
```
will raise `OperationalError` because of a malformed update query.

Example (after):
```python
class Item(Model):
    json = JSONField()

item = Item.create(json=['a','b'])
item.json = ['c','d']

Item.bulk_update([item], fields=[Item.json], unpack_values=False)
```
will update the row fine.

This applies to both SQLite and PostgreSQL `JSONField`s.