### PR TITLE
Add `.union` to the CTE class

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1057,6 +1057,11 @@ class CTE(_HashableSource, Source):
         return CTE(self._alias, clone + rhs, self._recursive, self._columns)
     __add__ = union_all
 
+    def union(self, rhs):
+        clone = self._query.clone()
+        return CTE(self._alias, clone | rhs, self._recursive, self._columns)
+    __or__ = union
+
     def __sql__(self, ctx):
         if ctx.scope != SCOPE_CTE:
             return ctx.sql(Entity(self._alias))

--- a/tests/models.py
+++ b/tests/models.py
@@ -2829,6 +2829,9 @@ class TestCTEIntegration(ModelTestCase):
         data = nodes_of(base_case.union_all(recursive))
         self.assertEqual(data, ['b', 'c', 'd', 'd'])
 
+        data = nodes_of(base_case.union(recursive))
+        self.assertEqual(data, ['b', 'c', 'd'])  # duplicate 'd' is removed
+
         # Add a cycle from D->A. union_all would spin forever
         Edge.create(a=d, b=a)
 


### PR DESCRIPTION
This complements the existing `union_all` method for CTE's.

`tests/sql.py` is purely syntactic b/c the following are identical
```
 echo 'WITH RECURSIVE "fibonacci" AS (SELECT 1 AS "n", 0 AS "fib_n", 1 AS "next_fib_n" UNION ALL SELECT ("fibonacci"."n" + 1) AS "n", "fibonacci"."next_fib_n", ("fibonacci"."fib_n" + "fibonacci"."next_fib_n") FROM "fibonacci" WHERE ("n" < 10)) SELECT "fibonacci"."n", "fibonacci"."fib_n" FROM "fibonacci";' | sqlite3
```
```
 echo 'WITH RECURSIVE "fibonacci" AS (SELECT 1 AS "n", 0 AS "fib_n", 1 AS "next_fib_n" UNION SELECT ("fibonacci"."n" + 1) AS "n", "fibonacci"."next_fib_n", ("fibonacci"."fib_n" + "fibonacci"."next_fib_n") FROM "fibonacci" WHERE ("n" < 10)) SELECT "fibonacci"."n", "fibonacci"."fib_n" FROM "fibonacci";' | sqlite3
```
`tests/models.py` adds a semantic test on the transitive closure of a directed graph. I tried to stay within the existing test models but needed a non-tree to be able to test properly.

Let me know if you'd like anything else from this


