### PR TITLE
Fix tests for UTC >=+ 4 timezones

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1063,7 +1063,7 @@ class TestTimestampField(ModelTestCase):
         y, m, d, H, M, S = ts_s
         self.assertEqual(y, 2019)
         self.assertEqual(m, 1)
-        self.assertEqual(d, 2)
+        self.assertEqual(d, dt_utc.day)
         self.assertEqual(H, dt_utc.hour)
         self.assertEqual(M, 4)
         self.assertEqual(S, 5)


### PR DESCRIPTION
Currently test_timestamp_field_from_ts assumes the timezone to be less than +4 so it remains the same day. This would fail when running with for example UTC+8:

```
======================================================================
FAIL: test_timestamp_field_parts (tests.fields.TestTimestampField)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/python-peewee/src/peewee-3.13.1/tests/fields.py", line 1066, in test_timestamp_field_parts
    self.assertEqual(d, 2)
AssertionError: 1 != 2

----------------------------------------------------------------------
Ran 859 tests in 3.450s

FAILED (failures=1, skipped=102)
```

Just comparing it with dt_utc.day fixes the failure.