### PR TITLE
add jsonb array oid

### DIFF
--- a/playhouse/reflection.py
+++ b/playhouse/reflection.py
@@ -252,6 +252,7 @@ class PostgresqlMetadata(Metadata):
         1182: DateField,
         1183: TimeField,
         2951: UUIDField,
+        3807: postgres_ext.BinaryJSONField,
     }
     extension_import = 'from playhouse.postgres_ext import *'
 


### PR DESCRIPTION
attempts to add JSONB array column to postgresql.

however unsure of how to use it. the generated code looks correct

however these fail:
```python
Model.update(array=[{}]).where(Model.id == 1).execute()
Model.create(array=[{}])
```