### PR TITLE
Improve reflection for AutoField/IntegerField

### DIFF
--- a/playhouse/reflection.py
+++ b/playhouse/reflection.py
@@ -176,7 +176,14 @@ class Metadata(object):
         if len(pk_names) == 1:
             pk = pk_names[0]
             if column_types[pk] is IntegerField:
-                column_types[pk] = AutoField
+                if isinstance(self.database, SqliteDatabase):
+                    column_types[pk] = AutoField
+                elif isinstance(self.database, PostgresqlDatabase) and \
+                        metadata[pk].default is not None:
+                    column_types[pk] = AutoField
+                elif isinstance(self.database, MySQLDatabase) and \
+                        metadata[pk].extra == 'auto_increment':
+                    column_types[pk] = AutoField
             elif column_types[pk] is BigIntegerField:
                 column_types[pk] = BigAutoField
 

--- a/tests/migrations.py
+++ b/tests/migrations.py
@@ -622,7 +622,8 @@ class TestSchemaMigration(ModelTestCase):
         _, tag = self.database.get_columns('tag')
         # name, type, null?, primary-key?, table, default.
         data_type = 'TEXT' if IS_SQLITE else 'text'
-        self.assertEqual(tag, ('tag', data_type, False, False, 'tag', None))
+        extra = '' if IS_MYSQL else None
+        self.assertEqual(tag, ('tag', data_type, False, False, 'tag', None, extra))
 
         # Convert date to datetime.
         field = DateTimeField()
@@ -644,7 +645,7 @@ class TestSchemaMigration(ModelTestCase):
             data_type = 'int'
         else:
             data_type = 'integer'
-        self.assertEqual(tag, ('tag', data_type, False, False, 'tag', None))
+        self.assertEqual(tag, ('tag', data_type, False, False, 'tag', None, extra))
 
     @requires_sqlite
     def test_valid_column_required(self):

--- a/tests/reflection.py
+++ b/tests/reflection.py
@@ -6,6 +6,7 @@ from peewee import *
 from playhouse.reflection import *
 
 from .base import IS_CRDB
+from .base import IS_SQLITE
 from .base import IS_SQLITE_OLD
 from .base import ModelTestCase
 from .base import TestModel
@@ -15,6 +16,10 @@ from .base import requires_sqlite
 from .base import skip_if
 from .base_models import Tweet
 from .base_models import User
+
+
+class IntegerFieldPrimaryKey(TestModel):
+    id = IntegerField(primary_key=True)
 
 
 class ColTypes(TestModel):
@@ -75,8 +80,8 @@ class BaseReflectionTestCase(ModelTestCase):
 
 
 class TestReflection(BaseReflectionTestCase):
-    requires = [ColTypes, Nullable, RelModel, FKPK, Underscores, Category,
-                Nugget]
+    requires = [IntegerFieldPrimaryKey, ColTypes, Nullable, RelModel, FKPK,
+                Underscores, Category, Nugget]
 
     def test_generate_models(self):
         models = self.introspector.generate_models()
@@ -84,6 +89,7 @@ class TestReflection(BaseReflectionTestCase):
             'category',
             'col_types',
             'fkpk',
+            'integer_field_primary_key',
             'nugget',
             'nullable',
             'rel_model',
@@ -233,6 +239,8 @@ class TestReflection(BaseReflectionTestCase):
          indexes) = self.introspector.introspect()
 
         expected = (
+            ('integer_field_primary_key', (
+                ('id', AutoField if IS_SQLITE else IntegerField, False),)),
             ('col_types', (
                 ('f1', (BigIntegerField, IntegerField), False),
                 # There do not appear to be separate constants for the blob and
@@ -386,6 +394,12 @@ class TestReflection(BaseReflectionTestCase):
          indexes) = self.introspector.introspect()
 
         expected = (
+            ('integer_field_primary_key', (
+                ('id', 'id = %s' %
+                 ('AutoField()'
+                 if IS_SQLITE
+                 else 'IntegerField(primary_key=True)')),
+            )),
             ('col_types', (
                 ('f1', ('f1 = BigIntegerField(index=True)',
                         'f1 = IntegerField(index=True)')),


### PR DESCRIPTION
Specifically, don't assume `IntegerField(primary_key=True)` is an `AutoField()` if the database isn't SQLite.

See https://github.com/coleifer/peewee/issues/2124 for more context.