### PR TITLE
Add missing parenthesis in sqlite_ext docs

### DIFF
--- a/docs/peewee/sqlite_ext.rst
+++ b/docs/peewee/sqlite_ext.rst
@@ -39,7 +39,7 @@ Instantiating a :py:class:`SqliteExtDatabase`:
     db = SqliteExtDatabase('my_app.db', pragmas=(
         ('cache_size', -1024 * 64),  # 64MB page-cache.
         ('journal_mode', 'wal'),  # Use WAL-mode (you should always use this!).
-        ('foreign_keys', 1))  # Enforce foreign-key constraints.
+        ('foreign_keys', 1)))  # Enforce foreign-key constraints.
 
 APIs
 ----


### PR DESCRIPTION
If you were to copy and paste the first example in the `Getting started` section of the sqlite_ext docs,
you'd get a `SyntaxError`.