### PR TITLE
Fix invalid escape sequence in regex

### DIFF
--- a/playhouse/cockroachdb.py
+++ b/playhouse/cockroachdb.py
@@ -68,7 +68,7 @@ class CockroachDatabase(PostgresqlDatabase):
         curs = conn.cursor()
         curs.execute('select version()')
         raw, = curs.fetchone()
-        match_obj = re.match('^CockroachDB.+?v(\d+)\.(\d+)\.(\d+)', raw)
+        match_obj = re.match(r'^CockroachDB.+?v(\d+)\.(\d+)\.(\d+)', raw)
         if match_obj is not None:
             clean = '%d%02d%02d' % tuple(int(i) for i in match_obj.groups())
             self.server_version = int(clean)  # 19.1.5 -> 190105.


### PR DESCRIPTION
Hello.
Lint tools told me about `\` in regex. I think it's better to be raw strings.

pycodestyle says me:
```
playhouse/cockroachdb.py:71:48: W605 invalid escape sequence '\d'
playhouse/cockroachdb.py:71:52: W605 invalid escape sequence '\.'
playhouse/cockroachdb.py:71:55: W605 invalid escape sequence '\d'
playhouse/cockroachdb.py:71:59: W605 invalid escape sequence '\.'
playhouse/cockroachdb.py:71:62: W605 invalid escape sequence '\d'
```

Also pylint says:
```
playhouse/cockroachdb.py:71:17: W1401: Anomalous backslash in string: '\d'. String constant might be missing an r prefix. (anomalous-backslash-in-string)
playhouse/cockroachdb.py:71:21: W1401: Anomalous backslash in string: '\.'. String constant might be missing an r prefix. (anomalous-backslash-in-string)
playhouse/cockroachdb.py:71:24: W1401: Anomalous backslash in string: '\d'. String constant might be missing an r prefix. (anomalous-backslash-in-string)
playhouse/cockroachdb.py:71:28: W1401: Anomalous backslash in string: '\.'. String constant might be missing an r prefix. (anomalous-backslash-in-string)
playhouse/cockroachdb.py:71:31: W1401: Anomalous backslash in string: '\d'. String constant might be missing an r prefix. (anomalous-backslash-in-string)
```

Reference https://stackoverflow.com/questions/19030952/pep8-warning-on-regex-string-in-python-eclipse