### PR TITLE
Support queries of all types of pkey in `get()`

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -6395,7 +6395,7 @@ class Model(with_metaclass(ModelBase, Node)):
         sq = cls.select()
         if query:
             # Handle simple lookup using just the primary key.
-            if len(query) == 1 and isinstance(query[0], int):
+            if len(query) == 1 and not isinstance(query[0], Node):
                 sq = sq.where(cls._meta.primary_key == query[0])
             else:
                 sq = sq.where(*query)


### PR DESCRIPTION
In https://github.com/coleifer/peewee/issues/1835 get by primary key is added for `int`, but there're cases when primary key is other than integer, especially in analytics domain.

Using `Node` to exclude `Expression` seems a good idea, need more insight though.