### PR TITLE
Use link_shared_object instead of link_executable in SQLite detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def _have_sqlite_extension_support():
     customize_compiler(compiler)
     success = False
     try:
-        compiler.link_executable(
+        compiler.link_shared_object(
             compiler.compile([src_file], output_dir=tmp_dir),
             bin_file,
             libraries=['sqlite3'])


### PR DESCRIPTION
`link_executable` doesn't use environment variable `LDFLAGS`, only environment variable `CC` (which usually only contains the name of the compiler, not the linking options)… which can be problematic and cause false negative on setups where SQLite is not installed in system path, but on a custom path.

Also the setup is not attempting to build an executable, but shared objects.
