### PR TITLE
Fix ModelSelect.get() documentation

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -2255,7 +2255,8 @@ Query-builder
     .. py:method:: get(database)
 
         :param Database database: database to execute query against.
-        :return: A single row from the database or ``None``.
+        :return: A single row from the database, or raises a <Model>DoesNotExist
+                 exception if there is none.
 
         Execute the query and return the first row, if it exists. Multiple
         calls will result in multiple queries being executed.


### PR DESCRIPTION
```
In [4]: (Transaction.select().where(Transaction.id == 999999)).get()
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
/usr/local/lib/python3.7/site-packages/peewee.py in get(self, database)
   6806         try:
-> 6807             return clone.execute(database)[0]
   6808         except IndexError:

/usr/local/lib/python3.7/site-packages/peewee.py in __getitem__(self, item)
   4225             self.fill_cache(item if item > 0 else 0)
-> 4226             return self.row_cache[item]
   4227         else:

IndexError: list index out of range

During handling of the above exception, another exception occurred:

TransactionDoesNotExist                   Traceback (most recent call last)
<ipython-input-4-23b2357d750a> in <module>
----> 1 (Transaction.select().where(Transaction.id == 999999)).get()

/usr/local/lib/python3.7/site-packages/peewee.py in get(self, database)
   6810             raise self.model.DoesNotExist('%s instance matching query does '
   6811                                           'not exist:\nSQL: %s\nParams: %s' %
-> 6812                                           (clone.model, sql, params))
   6813
   6814     @Node.copy

TransactionDoesNotExist: <Model: Transaction> instance matching query does not exist:
SQL: SELECT "t1"."id", "t1"."type", "t1"."account_prn", "t1"."cad", "t1"."amount_cents", "t1"."denied_amount_cents", "t1"."event_id", "t1"."network", "t1"."ach_trans_id", "t1"."open_to_buy_cents", "t1"."auth_txn_id", "t1"."activity_type", "t1"."auth_type", "t1"."description", "t1"."mcc", "t1"."passed_fraud_rules", "t1"."fraud_rules_results", "t1"."timestamp_at", "t1"."raw", "t1"."created_at" FROM "transaction" AS "t1" WHERE ("t1"."id" = %s) LIMIT %s OFFSET %s
Params: [999999, 1, 0]
```