### PR TITLE
Unexpected column names when using fn and .dicts

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -7378,7 +7378,7 @@ class BaseModelCursorWrapper(DictCursorWrapper):
             if dot_index != -1:
                 column = column[dot_index + 1:]
 
-            column = column.strip('"')
+            column = column.strip('")')
             self.columns.append(column)
             try:
                 raw_node = self.select[idx]


### PR DESCRIPTION
Consider the following example (I tried to shave it to a minimum):
```python
class Test(Model):
    start_date = DateTimeField(null=True)
    end_date = DateTimeField(null=True)

>>> list(Test.select(fn.MIN(Test.start_date), fn.MAX(Test.end_date)).dicts())
[{'start_date")': datetime.datetime(2020, 9, 11, 9, 56), 'end_date")': datetime.datetime(2020, 11, 29, 16, 0)}]
```

See the extra quote and parenthesis for the column names. One would expect something more like:
```python
>>> list(Test.select(fn.MIN(Test.start_date), fn.MAX(Test.end_date)).dicts())
[{'start_date': datetime.datetime(2020, 9, 11, 9, 56), 'end_date': datetime.datetime(2020, 11, 29, 16, 0)}]
```
I'm just proposing here to strip the colum names from the extra right parenthesis.