### PR TITLE
Add ability to create an instance from a back reference

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -7259,7 +7259,7 @@ class BackrefModelSelect(ModelSelect):
         self.from_field = from_field
         self.to_field = to_field
 
-        super(BackrefModelSelect, self).__init__(model, fields,
+        super(BackrefModelSelect, self).__init__(model, fields_or_models,
                                                  is_default=is_default)
 
     def create(self, **kwargs):

--- a/tests/regressions.py
+++ b/tests/regressions.py
@@ -1546,7 +1546,7 @@ class TestBackrefModelSelect(ModelTestCase):
         user2 = User.create(username='u2')
 
         tweet = user1.tweets.create(content='u1-1')
-        self.assertEqual(isinstance(tweet, Tweet))
+        self.assertTrue(isinstance(tweet, Tweet))
         self.assertEqual(tweet.user, user1)
         self.assertEqual(user1.tweets.count(), 1)
         self.assertEqual(user2.tweets.count(), 0)

--- a/tests/regressions.py
+++ b/tests/regressions.py
@@ -1536,3 +1536,17 @@ class TestModelConversionRegression(ModelTestCase):
         c0, c1, c2 = cpks
         query = CharFK.select().where(CharFK.cpk << [c0, c2])
         self.assertEqual(sorted([f.id for f in query]), [1, 3])
+
+
+class TestBackrefModelSelect(ModelTestCase):
+    requires = [User, Tweet]
+
+    def test_create_model_from_backref(self):
+        user1 = User.create(username='u1')
+        user2 = User.create(username='u2')
+
+        tweet = user1.tweets.create(content='u1-1')
+        self.assertEqual(isinstance(tweet, Tweet))
+        self.assertEqual(tweet.user, user1)
+        self.assertEqual(user1.tweets.count(), 1)
+        self.assertEqual(user2.tweets.count(), 0)


### PR DESCRIPTION
Allow an instance of a model to be created using the back reference.  For example, if I have a `User` and I want to create a `Tweet` for that user then allow it to be used as `user.tweets.create()`.

On a practical level this helps a lot when there are logs associated with a user or similar object.  Compare the above with having to import the log model and do `Log.create(user=user, otherparam=value)` which can cause circular import issues with large projects.

The patch provide is intended to provide an example.  I tried to fit the style but am open to any changes needed.

Thanks 