### PR TITLE
[Feature] Add support for the precision parameters to the FLOAT field

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -2846,7 +2846,10 @@ Fields
 
     .. attention:: Only supported by Postgres 10.0 and newer.
 
-.. py:class:: FloatField
+.. py:class:: FloatField([max_digits=None[, decimal_places=None]])
+
+    :param int max_digits: Maximum digits of accuracy to return.
+    :param int decimal_places: Number of decimal places to return.
 
     Field class for storing floating-point numbers.
 

--- a/docs/peewee/models.rst
+++ b/docs/peewee/models.rst
@@ -231,6 +231,8 @@ Some fields take special parameters...
 +--------------------------------+------------------------------------------------+
 | :py:class:`BareField`          | ``adapt``                                      |
 +--------------------------------+------------------------------------------------+
+| :py:class:`FloatField`         | ``max_digits``, ``decimal_places``             |
++--------------------------------+------------------------------------------------+
 
 .. note::
     Both ``default`` and ``choices`` could be implemented at the database level

--- a/peewee.py
+++ b/peewee.py
@@ -4639,6 +4639,17 @@ class PrimaryKeyField(AutoField):
 class FloatField(Field):
     field_type = 'FLOAT'
 
+    def __init__(self, *args, max_digits=None, decimal_places=None, **kwargs):
+        if decimal_places is not None and max_digits is None:
+            raise ValueError('The "max_digits" parameter must be provided when the '
+                             '"decimal_places" parameter is provided')
+        self.max_digits = max_digits
+        self.decimal_places = decimal_places
+        super(FloatField, self).__init__(*args, **kwargs)
+
+    def get_modifiers(self):
+        return [mod for mod in [self.max_digits, self.decimal_places] if mod is not None]
+
     def adapt(self, value):
         try:
             return float(value)


### PR DESCRIPTION
Hello, thank you so much for creating and maintaining this library! Peewee has been my go-to for several years now, both at work and on personal projects and it's honestly been a joy to use.

Recently I encountered a situation where I needed to specify the [precision parameters](https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html) for the MySQL `FLOAT` field, and after a search through this repo and the docs I ended up opening a [question on Stackoverflow](https://stackoverflow.com/questions/67475853/specify-float-column-precision-in-peewee-with-mariadb-mysql) where I got a very helpful answer that this patch is based on.

---

This patch adds two new init parameters to the `FloatField` class:
* `max_digits`, which corresponds to the `M` precision parameter on the MySQL `FLOAT` class and defines the number of digits that can be returned accurately from the column
* `decimal_places`, which corresponds to the `D` precision parameter on the MySQL `FLOAT` class and defines the number of digits after the decimal point which can be returned accurately from the column

Currently each of these new parameters has a default of `None` and are excluded from the return value of `get_modifiers()` so that the current behavior of the field isn't changed. However, if the defaults were changed to `max_digits=6` and `decimal_places=0` then the current behavior would be changed but the behavior of the field would be consistent across database backends.