### PR TITLE
Insert operations of models with non-PK foreign keys fail when passing a target object instance

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2681,7 +2681,11 @@ class Insert(_WriteQuery):
                     else:
                         raise ValueError('Missing value for %s.' % column.name)
 
-                if not isinstance(val, Node):
+                if isinstance(column,ForeignKeyField) or not isinstance(val, Node):
+                    # if the column is a ForeignKeyField, we have to re-wrap it even
+                    # if it is already a Node, because the ForeignKeyField could
+                    # operate on a non-pk column of the referenced (foreign) model object,
+                    # so we have to give its converter a chance to extract that column
                     val = Value(val, converter=converter, unpack=False)
                 values.append(val)
 


### PR DESCRIPTION
I have a model `A` with a `ForeignKeyField` column that uses the `field` parameter to set a non-pk reference column in the target model:

```python
class Target(Model):
    key = FixedCharField(8,unique=True)

class A(Model):
    target = ForeignKeyField(Target,field="key",lazy_load=False)
```

When trying to create instances of `A`, I can do so with `create()`, but not with the `ModelInsert`-based methods:

```python
t = Target.create(key="X")

A.create(target=t) # works

A.insert(target="X").execute() # works
A.insert(target=t).execute()   # fails
```

In the last case, the generated SQL uses the primary key of `t` instead of `t.key` because the code path in `ModelInsert` does not apply the `field` parameter of the `ForeignKeyField` to the passed-in model instance. The attached patch fixes the problem for me.