### PR TITLE
Fix decimal.InvalidOperation error for empty string

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -7480,7 +7480,7 @@ class ModelDictCursorWrapper(BaseModelCursorWrapper):
         for i in range(self.ncols):
             attr = columns[i]
             if attr in result: continue  # Don't overwrite if we have dupes.
-            if converters[i] is not None:
+            if converters[i] is not None and row[i] != '':
                 result[attr] = converters[i](row[i])
             else:
                 result[attr] = row[i]


### PR DESCRIPTION
Hello, thank you for making such a good opensource code!
I was working with [sqlite db viewer](https://github.com/nitinprakash96/sqlite-db-viewer) that uses peewee.
However, when I was trying to iterate through None values at integer field (by {% for row in query %} in html code), there was a peewee error saying decimal.InvalidOperation.
I think this issue could also be related with [this pull request](https://github.com/coleifer/peewee/commit/cd07f4e01a1262166d8944736e11d0681fb76214), since the error appeared at returning value of the function python_value `decimal.Decimal(text_type(value))`.

After inspection, I found out that sometimes an empty string('') comes into this function(which it shouldn't since empty string is not a number) and by adding a filter (adding `and row[i] != ''` at ModelDictCursorWrapper), I managed to solve this problem.

*Please note that I am new to this code and I may be not understanding this perfectly, so please correct me if I'm wrong in solving this problem. 
Attatched below is my original code, error traceback, and pdb operations.
Thank you!

### Error Traceback
![image](https://user-images.githubusercontent.com/29880214/124389717-5d123400-dd23-11eb-8370-e1d7925abe36.png)
![image](https://user-images.githubusercontent.com/29880214/124389742-8206a700-dd23-11eb-9c39-d4fdae1dd057.png)

### Setting try-catch pdb and results at python_value at peewee.py
![image](https://user-images.githubusercontent.com/29880214/124389767-a3679300-dd23-11eb-88b8-59d465eeaac7.png)
![image](https://user-images.githubusercontent.com/29880214/124389796-c09c6180-dd23-11eb-9b3c-1e28543263c0.png)

### Filtering String values
![image](https://user-images.githubusercontent.com/29880214/124389841-f2152d00-dd23-11eb-9130-c81ee1a011d2.png)

### Correctly displayed application (mine)
![image](https://user-images.githubusercontent.com/29880214/124389888-2557bc00-dd24-11eb-9451-eaa909f3e86f.png)
![image](https://user-images.githubusercontent.com/29880214/124389909-45877b00-dd24-11eb-9075-8963167d886a.png)

Here, I think what caused the problem is the ibb, hbp, sh, sf, g_idp column, which has Nonetype values as well as numbers(0). Adding this code to handle exceptions for this case would be great!