### PR TITLE
Fix link to SQLAlchemy Hybrid Attributes docs

### DIFF
--- a/docs/peewee/playhouse.rst
+++ b/docs/peewee/playhouse.rst
@@ -2046,7 +2046,7 @@ Hybrid Attributes
 
 Hybrid attributes encapsulate functionality that operates at both the Python
 *and* SQL levels. The idea for hybrid attributes comes from a feature of the
-`same name in SQLAlchemy <http://docs.sqlalchemy.org/en/improve_toc/orm/extensions/hybrid.html>`_.
+`same name in SQLAlchemy <https://docs.sqlalchemy.org/en/14/orm/extensions/hybrid.html>`_.
 Consider the following example:
 
 .. code-block:: python


### PR DESCRIPTION
Broken link: http://docs.sqlalchemy.org/en/improve_toc/orm/extensions/hybrid.html
New link: https://docs.sqlalchemy.org/en/14/orm/extensions/hybrid.html