### PR TITLE
Allow to use peewee.SQL from `from_`

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -7596,6 +7596,9 @@ class ModelCursorWrapper(BaseModelCursorWrapper):
                 accum.append(curr.rhs)
                 continue
 
+            if isinstance(curr, SQL):
+                continue
+
             if curr not in self.joins:
                 continue
 


### PR DESCRIPTION
**Problem:**
Tried to apply custom SQL to `from_` function from this example https://github.com/coleifer/peewee/issues/1289#issuecomment-307128658 However in my query, I use some joins.

Here is example
```python
q = User.select(User, Tweet).from_(SQL(f'`users` as `t1` USE INDEX(`user_id`) ')).join(Tweet)
for x in q:
   print(x)
```

But without fix, exception is thrown
```
Traceback (most recent call last):
  File "JetBrains\PyCharm2021.2\scratches\scratch_71.py", line 27, in <module>
    for file in q:
  File "venv\lib\site-packages\peewee.py", line 4408, in next
    self.cursor_wrapper.iterate()
  File "venv\lib\site-packages\peewee.py", line 4325, in iterate
    self.initialize()  # Lazy initialization.
  File "venv\lib\site-packages\peewee.py", line 7587, in initialize
    if curr not in self.joins:
TypeError: unhashable type: 'SQL'
```

**Solution**
When initializing ModelCursorWrapper skip SQL instances