### PR TITLE
Added optional use_column_names instead of field names in model_to_dict

### DIFF
--- a/playhouse/shortcuts.py
+++ b/playhouse/shortcuts.py
@@ -13,7 +13,8 @@ _clone_set = lambda s: set(s) if s else set()
 
 def model_to_dict(model, recurse=True, backrefs=False, only=None,
                   exclude=None, seen=None, extra_attrs=None,
-                  fields_from_query=None, max_depth=None, manytomany=False):
+                  fields_from_query=None, max_depth=None, manytomany=False,
+                  use_column_names=False):
     """
     Convert a model instance (and any related objects) to a dictionary.
 
@@ -69,6 +70,8 @@ def model_to_dict(model, recurse=True, backrefs=False, only=None,
                     only=only,
                     exclude=exclude,
                     max_depth=max_depth - 1))
+            if use_column_names:
+                name = model.fields[name].column_name
             data[name] = accum
 
     for field in model._meta.sorted_fields:
@@ -90,8 +93,11 @@ def model_to_dict(model, recurse=True, backrefs=False, only=None,
                     max_depth=max_depth - 1)
             else:
                 field_data = None
-
-        data[field.name] = field_data
+        if use_column_names:
+            field_name = field.column_name
+        else:
+            field_name = field.name
+        data[field_name] = field_data
 
     if extra_attrs:
         for attr_name in extra_attrs:


### PR DESCRIPTION
I am using this in model_to_dict in jobs because it makes the created python object keys consistent with the database column names when communicating through web apps. Despite column names are not case sensitive when querying, language mediums are, so it goes hand in hand with pwiz db_model.py tool. I didn't know what to do with backrefs though, hence left those lines. 