### PR TITLE
Fix count_queries to prevent couting pool events as queries.

### DIFF
--- a/playhouse/test_utils.py
+++ b/playhouse/test_utils.py
@@ -11,7 +11,8 @@ class _QueryLogHandler(logging.Handler):
         logging.Handler.__init__(self, *args, **kwargs)
 
     def emit(self, record):
-        self.queries.append(record)
+        if record.name == 'peewee':
+            self.queries.append(record)
 
 
 class count_queries(object):


### PR DESCRIPTION
When using the `count_queries()` function from the `playhouse.test_utils`, it does not give the expected count when you use a Pool. It includes things like opening a connection or returning the connection to the pool as a query.

The solution is to simply include log records from "peewee" not from "peewee.pool". I've tested this PR only on my local postgresql. 

Here is a demonstration of the bug:

```
from peewee import SQL
from playhouse.pool import PooledPostgresqlExtDatabase
from playhouse.test_utils import count_queries

db = PooledPostgresqlExtDatabase(
    'test', user='test', password='test', max_connections=1, autoconnect=False,
)

with count_queries() as counter:
    with db:
        db.execute(SQL('select 1'))

assert counter.count == 4

for query in counter.get_queries():
    print(query)


```

Here are the 4 queries recorded for me, instead of the expected 1.

```
<LogRecord: peewee.pool, 10, C:\test\lib\site-packages\playhouse\pool.py, 130, "No connection available in pool.">
<LogRecord: peewee.pool, 10, C:\test\lib\site-packages\playhouse\pool.py, 159, "Created new connection %s.">
<LogRecord: peewee, 10, C:\test\lib\site-packages\peewee.py, 3148, "('select 1', [])">
<LogRecord: peewee.pool, 10, C:\test\lib\site-packages\playhouse\pool.py, 186, "Returning %s to pool.">
```

The solution here is very simple, just make sure to only include logs emitted by "peewee" and nothing else (such as "peewee.pool").
