### PR TITLE
Add better support for left_outer_join convenience function

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2325,6 +2325,9 @@ class Select(SelectBase):
         item = self._from_list.pop()
         self._from_list.append(Join(item, dest, join_type, on))
 
+    def left_outer_join(self, dest, on=None):
+        return self.join(dest, JOIN.LEFT_OUTER, on)
+
     @Node.copy
     def group_by(self, *columns):
         grouping = []
@@ -7191,6 +7194,9 @@ class ModelSelect(BaseModelSelect, Select):
 
         item = self._from_list.pop()
         self._from_list.append(Join(item, dest, join_type, on))
+
+    def left_outer_join(self, dest, on=None, src=None, attr=None):
+        return self.join(dest, JOIN.LEFT_OUTER, on, src, attr)
 
     def join_from(self, src, dest, join_type=JOIN.INNER, on=None, attr=None):
         return self.join(dest, join_type, on, src, attr)

--- a/tests/model_sql.py
+++ b/tests/model_sql.py
@@ -171,6 +171,19 @@ class TestModelSQL(ModelDatabaseTestCase):
             'INNER JOIN "favorite" AS "t3" ON ("t3"."tweet_id" = "t1"."id")'),
             [])
 
+        query = Tweet.select(Tweet.id).left_outer_join(Favorite).switch(Tweet).left_outer_join(User)
+        self.assertSQL(query, (
+            'SELECT "t1"."id" FROM "tweet" AS "t1" '
+            'LEFT OUTER JOIN "favorite" AS "t2" ON ("t2"."tweet_id" = "t1"."id") '
+            'LEFT OUTER JOIN "users" AS "t3" ON ("t1"."user_id" = "t3"."id")'), [])
+
+        query = Tweet.select(Tweet.id).left_outer_join(User).switch(Tweet).left_outer_join(Favorite)
+        self.assertSQL(query, (
+            'SELECT "t1"."id" FROM "tweet" AS "t1" '
+            'LEFT OUTER JOIN "users" AS "t2" ON ("t1"."user_id" = "t2"."id") '
+            'LEFT OUTER JOIN "favorite" AS "t3" ON ("t3"."tweet_id" = "t1"."id")'),
+            [])
+
     def test_model_alias(self):
         TA = Tweet.alias()
         query = (User


### PR DESCRIPTION
The `Source` class has a `left_outer_join` convenience function which calls `join`. However, unlike `join`, the `left_outer_join` function is not overridden in `Select` and `ModelSelect`.

Currently, this means that doing `User.select().left_outer_join(Tweet)` returns a `Join` object, not a `ModelSelect`. 

This is inconsistent with `User.select().join(Tweet)` which returns a `ModelSelect`. For example the following fails today because there is no `switch` function defined on the `Join` object:

    Tweet.select().left_outer_join(User).switch

The `Join` object also has no `where`, `sql`, or `execute` functions, which effectively means this `left_outer_join` function cannot be used today.

---

This PR adds the `left_outer_join` convenience function to the `Select` and `ModelSelect` classes.

---

One thing to consider is whether or not it might be better to name this `outerjoin` instead of `left_outer_join`. `outerjoin` would be [consistent with SQLAlchemy](https://docs.sqlalchemy.org/en/14/core/selectable.html#sqlalchemy.sql.expression.FromClause.outerjoin) if that was desirable.  Or perhaps just shorten `left_outer_join` to `outer_join` or `left_join`.

If you wanted to, I think it *might* be safe to rename this function without breaking backwards compatibility. Because the current Tweet.select().left_outer_join(User) is returning a `Join` object which cannot be used in any context at least that I can think of. E.g., it has no execute(), where(), sql() functions.

----

I added a test for this which is passing. However I found that a few other tests are failing, my guess is that they were already failing before this change. Thee following failed for me: test_close_stale (tests.pool.TestPooledDatabase), test_timestamp_field_from_ts (tests.fields.TestTimestampField), test_timestamp_field_parts (tests.fields.TestTimestampField)
. 
