### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,9 @@ def _do_setup(c_extensions, sqlite_extensions):
         author='Charles Leifer',
         author_email='coleifer@gmail.com',
         url='https://github.com/coleifer/peewee/',
+        project_urls={
+            'Source': 'https://github.com/coleifer/peewee',
+        },
         packages=['playhouse'],
         py_modules=['peewee', 'pwiz'],
         classifiers=[


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)