### PR TITLE
Update database.rst

### DIFF
--- a/docs/peewee/database.rst
+++ b/docs/peewee/database.rst
@@ -536,8 +536,8 @@ documentation.
 APSW, an Advanced SQLite Driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Peewee also comes with an alternate SQLite database that uses :ref:`apsw`.
-More information on APSW can be obtained on the
+Peewee also comes with an alternate SQLite database that uses `APSW <apsw>`_,
+an advanced Python SQLite driver. More information on APSW can be obtained on the
 `APSW project website <https://code.google.com/p/apsw/>`_. APSW provides
 special features like:
 

--- a/docs/peewee/database.rst
+++ b/docs/peewee/database.rst
@@ -536,8 +536,8 @@ documentation.
 APSW, an Advanced SQLite Driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Peewee also comes with an alternate SQLite database that uses :ref:`apsw`, an
-advanced Python SQLite driver. More information on APSW can be obtained on the
+Peewee also comes with an alternate SQLite database that uses :ref:`apsw`.
+More information on APSW can be obtained on the
 `APSW project website <https://code.google.com/p/apsw/>`_. APSW provides
 special features like:
 


### PR DESCRIPTION
If the apsw **reference is rendered,** the text reads (emphasis mine):

> Peewee also comes with an alternate SQLite database that uses **apsw, an advanced sqlite driver**, an advanced Python SQLite driver.

I know that the idea is to describe the reference without relying on the self-description of the reference, but in this case they are (almost)identical. Another way would be to shorten the ref to just apsw, if restructured text permits that.