### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/peewee/query_examples.rst
+++ b/docs/peewee/query_examples.rst
@@ -328,7 +328,7 @@ Joins and Subqueries
 This category deals primarily with a foundational concept in relational
 database systems: joining. Joining allows you to combine related information
 from multiple tables to answer a question. This isn't just beneficial for ease
-of querying: a lack of join capability encourages denormalisation of data,
+of querying: a lack of join capability encourages denormalization of data,
 which increases the complexity of keeping your data internally consistent.
 
 This topic covers inner, outer, and self joins, as well as spending a little

--- a/peewee.py
+++ b/peewee.py
@@ -1849,7 +1849,7 @@ class QualifiedNames(WrappedNode):
 
 
 def qualify_names(node):
-    # Search a node heirarchy to ensure that any column-like objects are
+    # Search a node hierarchy to ensure that any column-like objects are
     # referenced using fully-qualified names.
     if isinstance(node, Expression):
         return node.__class__(qualify_names(node.lhs), node.op,

--- a/tests/model_save.py
+++ b/tests/model_save.py
@@ -109,7 +109,7 @@ class TestPrimaryKeySaveHandling(ModelTestCase):
     def test_composite_pk(self):
         t4 = T4(pk1=1, pk2=2, value=10)
 
-        # Will attempt to do an update on non-existant rows.
+        # Will attempt to do an update on non-existent rows.
         self.assertEqual(t4.save(), 0)
         self.assertEqual(t4.save(force_insert=True), 1)
 

--- a/tests/postgres_helpers.py
+++ b/tests/postgres_helpers.py
@@ -205,7 +205,7 @@ class BaseBinaryJsonFieldTestCase(BaseJsonFieldTestCase):
         self._create_test_data()
         D = self.M.data
 
-        # 'k3' is mapped to another dictioary {'k4': [...]}. Therefore,
+        # 'k3' is mapped to another dictionary {'k4': [...]}. Therefore,
         # 'k3' is said to contain 'k4', but *not* ['k4'] or ['k4', 'k5'].
         self.assertObjects(D['k3'].contains('k4'), 0)
         self.assertObjects(D['k3'].contains(['k4']))


### PR DESCRIPTION
There are small typos in:
- docs/peewee/query_examples.rst
- peewee.py
- tests/model_save.py
- tests/postgres_helpers.py

Fixes:
- Should read `hierarchy` rather than `heirarchy`.
- Should read `existent` rather than `existant`.
- Should read `dictionary` rather than `dictioary`.
- Should read `denormalization` rather than `denormalisation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md