### PR TITLE
Added special expressions to boolean field

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -5253,6 +5253,15 @@ class BooleanField(Field):
     field_type = 'BOOL'
     adapt = bool
 
+    # Special expressions
+    def is_true(self, is_true=True):
+        op = OP.EQ if is_true else OP.NE
+        return Expression(self, op, 1)
+
+    def is_false(self, is_false=True):
+        op = OP.EQ if is_false else OP.NE
+        return Expression(self, op, 0)
+
 
 class BareField(Field):
     def __init__(self, adapt=None, *args, **kwargs):


### PR DESCRIPTION
Added an expression so that in the request instead of:
```python
Model.select().where(Model.boolean_field == True)
````
To write:
```python
Model.select().where(Model.boolean_field.is_true())
````

The same expression already exists:
https://github.com/alteralt/peewee/blob/b8c629bc100c4886c5b87b6eb62cce66c84a0d9c/peewee.py#L1197