### PR TITLE
Add `SelectBase.scalars()`

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2212,6 +2212,10 @@ class SelectBase(_HashableSource, Source, SelectQuery):
         return row[0] if row and not as_tuple else row
 
     @database_required
+    def scalars(self, database):
+        return [t[0] for t in self.tuples()]
+
+    @database_required
     def count(self, database, clear_limit=False):
         clone = self.order_by().alias('_wrapped')
         if clear_limit:

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -116,6 +116,18 @@ class TestQueryExecution(DatabaseTestCase):
         query = query.where(Register.value >= 2)
         self.assertEqual(query.scalar(as_tuple=True), (15, 3, 5))
 
+    def test_scalars(self):
+        values = [1.0, 1.5, 2.0, 5.0, 8.0]
+        (Register
+         .insert([{Register.value: value} for value in values])
+         .execute())
+
+        query = Register.select(Register.value)
+        self.assertEqual(query.scalars(), [1.0, 1.5, 2.0, 5.0, 8.0])
+
+        query = query.where(Register.value < 5)
+        self.assertEqual(query.scalars(), [1.0, 1.5, 2.0])
+
     def test_slicing_select(self):
         values = [1., 1., 2., 3., 5., 8.]
         (Register


### PR DESCRIPTION
Mr. Leifer, thanks for creating and maintaining such a great library. We've used peewee at Propel since 2015.

This PR adds `SelectBase.scalars()`, which is something we've wanted for a while. `scalar()` is very convenient, and we thought something similar for multiple values would be too. I've proposed `scalars()` as the name, but would be happy to settle on something else if you prefer.

Thanks for considering.