### PR TITLE
Skip test_murmur_hash on big endian architectures

### DIFF
--- a/tests/sqlite.py
+++ b/tests/sqlite.py
@@ -1572,6 +1572,7 @@ class TestMurmurHash(ModelTestCase):
         cursor = self.database.execute(query)
         self.assertEqual(cursor.fetchone()[0], e)
 
+    @skip_if(sys.byteorder == 'big', 'fails on big endian')
     def test_murmur_hash(self):
         self.assertHash('testkey', 2871421366)
         self.assertHash('murmur', 3883399899)


### PR DESCRIPTION
Resolves #2619