### PR TITLE
Forward class creation keyword arguments

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -6268,9 +6268,9 @@ class ModelBase(type):
                        'only_save_dirty', 'legacy_table_names',
                        'table_settings', 'strict_tables'])
 
-    def __new__(cls, name, bases, attrs):
+    def __new__(cls, name, bases, attrs, **kwargs):
         if name == MODEL_BASE or bases[0].__name__ == MODEL_BASE:
-            return super(ModelBase, cls).__new__(cls, name, bases, attrs)
+            return super(ModelBase, cls).__new__(cls, name, bases, attrs, **kwargs)
 
         meta_options = {}
         meta = attrs.pop('Meta', None)
@@ -6310,7 +6310,7 @@ class ModelBase(type):
         Schema = meta_options.get('schema_manager_class', SchemaManager)
 
         # Construct the new class.
-        cls = super(ModelBase, cls).__new__(cls, name, bases, attrs)
+        cls = super(ModelBase, cls).__new__(cls, name, bases, attrs, **kwargs)
         cls.__data__ = cls.__rel__ = None
 
         cls._meta = Meta(cls, **meta_options)


### PR DESCRIPTION
https://docs.python.org/3/library/functions.html#type

I wanted to be able to create a template model which other models inherit from and modify, by passing keyword arguments in the class definition. However, the current implementation of `ModelBase` does not pass along those arguments which results in errors like

```
TypeError: ModelBase.__new__() got an unexpected keyword argument 'custom_arg'
```

---

Example code:

Base class
```py
class Foo(pw.Model):
    foo_type: pw.CharField

    @classmethod
    def __init_subclass__(
        cls, foo_type_default: str
    ) -> None:
        cls.foo_type = pw.CharField(
            choices=(
                ("bar", "Bar"),
                ("foobar", "Foobar"),
            ),
            default=foo_type_default,
        )
```

Subclass1
```py
class Bar(Foo, foo_type_default="bar"):
    pass
```

Subclass2
```py
class FooBar(Foo, foo_type_default="foobar"):
    pass
```

With the current implementation, the above doesn't work. This PR fixes that.