### PR TITLE
Support IN and INNER JOIN subqueries on prefetch

### DIFF
--- a/docs/peewee/api.rst
+++ b/docs/peewee/api.rst
@@ -4784,13 +4784,19 @@ Model
 
         Use Django-style filters to express a WHERE clause.
 
-    .. py:method:: prefetch(*subqueries)
+    .. py:method:: prefetch(*subqueries[, prefetch_type=PREFETCH_TYPE.WHERE])
 
         :param subqueries: A list of :py:class:`Model` classes or select
             queries to prefetch.
+        :param prefetch_type: Query type to use for the subqueries.
         :returns: a list of models with selected relations prefetched.
 
         Execute the query, prefetching the given additional resources.
+
+        Prefetch type may be one of:
+
+        * ``PREFETCH_TYPE.WHERE``
+        * ``PREFETCH_TYPE.JOIN``
 
         See also :py:func:`prefetch` standalone function.
 
@@ -4812,15 +4818,23 @@ Model
             mapped correctly.
 
 
-.. py:function:: prefetch(sq, *subqueries)
+.. py:function:: prefetch(sq, *subqueries[, prefetch_type=PREFETCH_TYPE.WHERE])
 
     :param sq: Query to use as starting-point.
     :param subqueries: One or more models or :py:class:`ModelSelect` queries
         to eagerly fetch.
+    :param prefetch_type: Query type to use for the subqueries.
     :returns: a list of models with selected relations prefetched.
 
     Eagerly fetch related objects, allowing efficient querying of multiple
-    tables when a 1-to-many relationship exists.
+    tables when a 1-to-many relationship exists. The prefetch type changes how
+    the subqueries are constructed which may be desirable dependending on the
+    database engine in use.
+
+        Prefetch type may be one of:
+
+        * ``PREFETCH_TYPE.WHERE``
+        * ``PREFETCH_TYPE.JOIN``
 
     For example, it is simple to query a many-to-1 relationship efficiently::
 

--- a/docs/peewee/relationships.rst
+++ b/docs/peewee/relationships.rst
@@ -1005,3 +1005,5 @@ Some things to consider when using :py:func:`prefetch`:
 * Foreign keys must exist between the models being prefetched.
 * `LIMIT` works as you'd expect on the outer-most query, but may be difficult
   to implement correctly if trying to limit the size of the sub-selects.
+  * The parameter `prefetch_type` may be used when `LIMIT` is not supported
+    with the default query construction (e.g. with MySQL).

--- a/peewee.py
+++ b/peewee.py
@@ -129,6 +129,7 @@ __all__ = [
     'PostgresqlDatabase',
     'PrimaryKeyField',  # XXX: Deprecated, change to AutoField.
     'prefetch',
+    'PREFETCH_TYPE',
     'ProgrammingError',
     'Proxy',
     'QualifiedNames',
@@ -345,6 +346,11 @@ ROW = attrdict(
     NAMED_TUPLE=3,
     CONSTRUCTOR=4,
     MODEL=5)
+
+# Query type to use with prefetch
+PREFETCH_TYPE = attrdict(
+    WHERE=1,
+    JOIN=2)
 
 SCOPE_NORMAL = 1
 SCOPE_SOURCE = 2
@@ -7041,8 +7047,8 @@ class BaseModelSelect(_ModelQueryHelper):
             self.execute()
         return iter(self._cursor_wrapper)
 
-    def prefetch(self, *subqueries):
-        return prefetch(self, *subqueries)
+    def prefetch(self, *subqueries, prefetch_type=PREFETCH_TYPE.WHERE):
+        return prefetch(self, *subqueries, prefetch_type=prefetch_type)
 
     def get(self, database=None):
         clone = self.paginate(1, 1)
@@ -7867,7 +7873,7 @@ class PrefetchQuery(collections.namedtuple('_PrefetchQuery', (
                 id_map[key].append(instance)
 
 
-def prefetch_add_subquery(sq, subqueries):
+def prefetch_add_subquery(sq, subqueries, prefetch_type):
     fixed_queries = [PrefetchQuery(sq)]
     for i, subquery in enumerate(subqueries):
         if isinstance(subquery, tuple):
@@ -7903,32 +7909,50 @@ def prefetch_add_subquery(sq, subqueries):
         dest = (target_model,) if target_model else None
 
         if fks:
-            expr = []
-            select_pks = []
-            for fk, pk in zip(fks, pks):
-                expr.append(getattr(last_query.c, pk.column_name) == fk)
-                select_pks.append(pk)
-            subquery = subquery.distinct().join(last_query.select(*select_pks), on=reduce(operator.or_, expr))
+            if prefetch_type == PREFETCH_TYPE.WHERE:
+                expr = reduce(operator.or_, [
+                    (fk << last_query.select(pk))
+                    for (fk, pk) in zip(fks, pks)])
+                subquery = subquery.where(expr)
+            elif prefetch_type == PREFETCH_TYPE.JOIN:
+                expr = []
+                select_pks = []
+                for fk, pk in zip(fks, pks):
+                    expr.append(getattr(last_query.c, pk.column_name) == fk)
+                    select_pks.append(pk)
+                subquery = subquery.distinct().join(last_query.select(*select_pks),
+                                                    on=reduce(operator.or_, expr))
             fixed_queries.append(PrefetchQuery(subquery, fks, False, dest))
         elif backrefs:
             expressions = []
-            select_fks = []
-            for backref in backrefs:
-                rel_field = getattr(subquery_model, backref.rel_field.name)
-                fk_field = getattr(last_obj, backref.name)
-                select_fks.append(fk_field)
-                expressions.append(rel_field == getattr(last_query.c, fk_field.column_name))
-            subquery = subquery.distinct().join(last_query.select(*select_fks), on=reduce(operator.or_, expressions))
+            def fields():
+                for backref in backrefs:
+                    rel_field = getattr(subquery_model, backref.rel_field.name)
+                    fk_field = getattr(last_obj, backref.name)
+                    yield (rel_field, fk_field)
+
+            if prefetch_type == PREFETCH_TYPE.WHERE:
+                for rel_field, fk_field in fields():
+                    expressions.append(rel_field << last_query.select(fk_field))
+                subquery = subquery.where(reduce(operator.or_, expressions))
+            elif prefetch_type == PREFETCH_TYPE.JOIN:
+                select_fks = []
+                for rel_field, fk_field in fields():
+                    select_fks.append(fk_field)
+                    expressions.append(
+                        rel_field == getattr(last_query.c, fk_field.column_name))
+                subquery = subquery.distinct().join(last_query.select(*select_fks),
+                                         on=reduce(operator.or_, expressions))
             fixed_queries.append(PrefetchQuery(subquery, backrefs, True, dest))
 
     return fixed_queries
 
 
-def prefetch(sq, *subqueries):
+def prefetch(sq, *subqueries, prefetch_type=PREFETCH_TYPE.WHERE):
     if not subqueries:
         return sq
 
-    fixed_queries = prefetch_add_subquery(sq, subqueries)
+    fixed_queries = prefetch_add_subquery(sq, subqueries, prefetch_type)
     deps = {}
     rel_map = {}
     for pq in reversed(fixed_queries):

--- a/tests/manytomany.py
+++ b/tests/manytomany.py
@@ -277,33 +277,37 @@ class TestManyToMany(ModelTestCase):
 
     def test_prefetch_notes(self):
         self._set_data()
-        with self.assertQueryCount(3):
-            gargie, huey, mickey, zaizee = prefetch(
-                User.select().order_by(User.username),
-                NoteUserThrough,
-                Note)
+        for pt in PREFETCH_TYPE.values():
+            with self.assertQueryCount(3):
+                gargie, huey, mickey, zaizee = prefetch(
+                    User.select().order_by(User.username),
+                    NoteUserThrough,
+                    Note,
+                    prefetch_type=pt)
 
-        with self.assertQueryCount(0):
-            self.assertNotes(gargie.notes, [1, 2])
-        with self.assertQueryCount(0):
-            self.assertNotes(zaizee.notes, [4, 5])
+            with self.assertQueryCount(0):
+                self.assertNotes(gargie.notes, [1, 2])
+            with self.assertQueryCount(0):
+                self.assertNotes(zaizee.notes, [4, 5])
         with self.assertQueryCount(2):
             self.assertNotes(User.create(username='x').notes, [])
 
     def test_prefetch_users(self):
         self._set_data()
-        with self.assertQueryCount(3):
-            n1, n2, n3, n4, n5 = prefetch(
-                Note.select().order_by(Note.text),
-                NoteUserThrough,
-                User)
+        for pt in PREFETCH_TYPE.values():
+            with self.assertQueryCount(3):
+                n1, n2, n3, n4, n5 = prefetch(
+                    Note.select().order_by(Note.text),
+                    NoteUserThrough,
+                    User,
+                    prefetch_type=pt)
 
-        with self.assertQueryCount(0):
-            self.assertUsers(n1.users, ['gargie'])
-        with self.assertQueryCount(0):
-            self.assertUsers(n2.users, ['gargie', 'huey'])
-        with self.assertQueryCount(0):
-            self.assertUsers(n5.users, ['zaizee'])
+            with self.assertQueryCount(0):
+                self.assertUsers(n1.users, ['gargie'])
+            with self.assertQueryCount(0):
+                self.assertUsers(n2.users, ['gargie', 'huey'])
+            with self.assertQueryCount(0):
+                self.assertUsers(n5.users, ['zaizee'])
         with self.assertQueryCount(2):
             self.assertUsers(Note.create(text='x').users, [])
 

--- a/tests/prefetch_tests.py
+++ b/tests/prefetch_tests.py
@@ -373,6 +373,7 @@ class TestPrefetch(ModelTestCase):
         r4 = RC(z, c)
 
         def assertRelationships(attr, values):
+            self.assertEqual(len(attr),len(values))
             for relationship, value in zip(attr, values):
                 self.assertEqual(relationship.__data__, value)
 


### PR DESCRIPTION
This PR intends to solve #2631 

It adds a parameter to `prefetch` that allows the user to choose the type of subquery performed. Using `INNER JOIN` is desirable when combining `LIMIT` with MySQL as the current implementation is not compatible.

Usage example 
```python
from peewee import PREFETCH_TYPE

people = Person.select().order_by(Person.name)
query = people.prefetch(Note, NoteItem, prefetch_type=PREFETCH_TYPE.JOIN)
```

The current behavior should remain the same as `prefetch_type` default to using the current implementation. I suggest whitespace changes are ignored when diffing `prefetch_tests.py`.

It goes without saying, but any feedback is welcome.