### PR TITLE
query.first() mutates the query

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2215,10 +2215,10 @@ class SelectBase(_HashableSource, Source, SelectQuery):
 
     @database_required
     def first(self, database, n=1):
+        query = self
         if self._limit != n:
-            self._limit = n
-            self._cursor_wrapper = None
-        return self.peek(database, n=n)
+            query = self.limit(n)
+        return query.peek(database, n=n)
 
     @database_required
     def scalar(self, database, as_tuple=False, as_dict=False):

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -62,6 +62,7 @@ class TestQueryExecution(DatabaseTestCase):
             {'content': 'meow'},
             {'content': 'purr'}])
         self.assertEqual(query.first(), {'content': 'meow'})
+        self.assertEqual(query.count(), 4)
 
         query = Tweet.select().where(Tweet.id == 0)
         self.assertIsNone(query.peek(n=2))

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -62,7 +62,7 @@ class TestQueryExecution(DatabaseTestCase):
             {'content': 'meow'},
             {'content': 'purr'}])
         self.assertEqual(query.first(), {'content': 'meow'})
-        self.assertEqual(query.count(), 4)
+        self.assertEqual(query.count(), 3)
 
         query = Tweet.select().where(Tweet.id == 0)
         self.assertIsNone(query.peek(n=2))


### PR DESCRIPTION
The `query.first()` method mutates the query and it may lead to unexpected behaviour

```python
query = SomeModel.select()
first_item = query.first()
for item in query:
    # This cycle only runs once, because after first() the query is mutated and now it has limit 1
```

The PR fixes the behaviour.