### PR TITLE
Feature/filter none on where

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -1935,6 +1935,8 @@ class OnConflict(Node):
 
     @Node.copy
     def where(self, *expressions):
+        expressions = [
+            expression for expression in expressions if expression is not None]
         if self._where is not None:
             expressions = (self._where,) + expressions
         self._where = reduce(operator.and_, expressions)
@@ -2108,12 +2110,16 @@ class Query(BaseQuery):
 
     @Node.copy
     def where(self, *expressions):
+        expressions = [
+            expression for expression in expressions if expression is not None]
         if self._where is not None:
             expressions = (self._where,) + expressions
         self._where = reduce(operator.and_, expressions)
 
     @Node.copy
     def orwhere(self, *expressions):
+        expressions = [
+            expression for expression in expressions if expression is not None]
         if self._where is not None:
             expressions = (self._where,) + expressions
         self._where = reduce(operator.or_, expressions)
@@ -2882,6 +2888,8 @@ class Index(Node):
 
     @Node.copy
     def where(self, *expressions):
+        expressions = [
+            expression for expression in expressions if expression is not None]
         if self._where is not None:
             expressions = (self._where,) + expressions
         self._where = reduce(operator.and_, expressions)

--- a/peewee.py
+++ b/peewee.py
@@ -1937,6 +1937,8 @@ class OnConflict(Node):
     def where(self, *expressions):
         expressions = [
             expression for expression in expressions if expression is not None]
+        if not expressions:
+            return
         if self._where is not None:
             expressions = (self._where,) + expressions
         self._where = reduce(operator.and_, expressions)
@@ -2112,6 +2114,8 @@ class Query(BaseQuery):
     def where(self, *expressions):
         expressions = [
             expression for expression in expressions if expression is not None]
+        if not expressions:
+            return
         if self._where is not None:
             expressions = (self._where,) + expressions
         self._where = reduce(operator.and_, expressions)
@@ -2120,6 +2124,8 @@ class Query(BaseQuery):
     def orwhere(self, *expressions):
         expressions = [
             expression for expression in expressions if expression is not None]
+        if not expressions:
+            return
         if self._where is not None:
             expressions = (self._where,) + expressions
         self._where = reduce(operator.or_, expressions)
@@ -2890,6 +2896,8 @@ class Index(Node):
     def where(self, *expressions):
         expressions = [
             expression for expression in expressions if expression is not None]
+        if not expressions:
+            return
         if self._where is not None:
             expressions = (self._where,) + expressions
         self._where = reduce(operator.and_, expressions)


### PR DESCRIPTION
```python
q = SeriesTable.select().where(
    None, None
)

```

If where is called for the first time and where has more than one None parameter, an error will occur:

```shell
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/ponponon/Desktop/code/me/gs_review_api/dev/peewee_in.py", line 32, in <module>
    q = SeriesTable.select().where(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ponponon/.local/share/virtualenvs/gs_review_api-0lO5qGKr/lib/python3.11/site-packages/peewee.py", line 755, in inner
    method(clone, *args, **kwargs)
  File "/Users/ponponon/.local/share/virtualenvs/gs_review_api-0lO5qGKr/lib/python3.11/site-packages/peewee.py", line 2156, in where
    self._where = reduce(operator.and_, expressions)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported operand type(s) for &: 'NoneType' and 'NoneType'
```

So we filter the parameters of where and ignore those with the value None to avoid errors

