### PR TITLE
Fix bug so models with BigBitFields can be bulk created and updated

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -5074,6 +5074,8 @@ class BigBitField(BlobField):
         super(BigBitField, self).__init__(*args, **kwargs)
 
     def db_value(self, value):
+        if isinstance(value, BigBitFieldData):
+            return bytes_type(value._buffer)
         return bytes_type(value) if value is not None else value
 
 


### PR DESCRIPTION
Any model with a `BigBitField` cannot be created in bulk using `Model.bulk_create(...)` or updated in bulk using `Model.bulk_update(...)`. This PR fixes that.

Here is a minimum reproducible example that was tested with PostgreSQL and `peewee` 3.15.2:

````python
from peewee import *

database = ...

class MRE(Model):

    pk = AutoField()
    flags = BigBitField(null=True)

    class Meta:
        database = database

with database.atomic():
    database.create_tables([MRE])

# This works:
first_obj = MRE.create()
second_obj = MRE.create()

# This works:
for i in range(1, 10):
    first_obj.flags.set_bit(i)
    second_obj.flags.set_bit(i)

# This works:
first_obj.save()
second_obj.save()

for i in range(10, 20):
    first_obj.flags.set_bit(i)
    second_obj.flags.set_bit(i)

# This works:
first_obj.save()

# This fails:
with database.atomic():
    MRE.bulk_update([second_obj], fields=[MRE.flags])

# This also fails:
with database.atomic():
    MRE.bulk_create([MRE(), MRE(), MRE()])
````

With this PR, the failures disappear 🪄 