### PR TITLE
Allow FlagDescriptors to have `help_text`

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4978,9 +4978,10 @@ class BitField(BitwiseMixin, BigIntegerField):
             self.__current_flag = value << 1
 
         class FlagDescriptor(ColumnBase):
-            def __init__(self, field, value):
+            def __init__(self, field, value, help_text=None):
                 self._field = field
                 self._value = value
+                self.help_text = help_text
                 super(FlagDescriptor, self).__init__()
             def clear(self):
                 return self._field.bin_and(~self._value)
@@ -5002,7 +5003,7 @@ class BitField(BitwiseMixin, BigIntegerField):
                 setattr(instance, self._field.name, value)
             def __sql__(self, ctx):
                 return ctx.sql(self._field.bin_and(self._value) != 0)
-        return FlagDescriptor(self, value)
+        return FlagDescriptor(self, value, help_text)
 
 
 class BigBitFieldData(object):


### PR DESCRIPTION
I find the `BitField` to be very helpful.

I also find it helpful to set flag descriptors for things I might want to query by, or set. For example:

````python
class Source(Model):

    sqf_flags = BitField(default=0)
 
    flag_bad_dark_pixel = sqf_flags.flag(2**0)
    ...
    flag_edge_of_frame = sqf_flags.flag(2**29)
````

While the `flag_[THING]` is reasonably informative here, it's never fully descriptive. I like to add `help_text` attributes to these flags so that I can better document why the thing is flagged, and to create a table explaining the bit flags. This is also useful for creating documentation pages that explain the bit flags for any muggles who are not using Python or `peewee`.

This pull request changes the `FlagDescriptor` class definition to allow an optional `help_text` keyword argument so that these kinds of self-documenting flags are now available:

````python
class Source(Model):

    sqf_flags = BitField(default=0)
 
    flag_bad_dark_pixel = sqf_flags.flag(
        2**0, 
        help_text="Dark frame flux count below 100 in this pixel"
    )
    ...
    flag_edge_of_frame = sqf_flags.flag(
        2**29, 
        help_text="Source within 3 pixels of original image edge"
    )
````