### PR TITLE
Cover transaction begin in ReconnectMixin

### DIFF
--- a/playhouse/shortcuts.py
+++ b/playhouse/shortcuts.py
@@ -252,8 +252,14 @@ class ReconnectMixin(object):
     def execute_sql(self, sql, params=None, commit=None):
         if commit is not None:
             __deprecated__('"commit" has been deprecated and is a no-op.')
+        return self._reconnect(super(ReconnectMixin, self).execute_sql, sql, params)
+
+    def begin(self):
+        return self._reconnect(super(ReconnectMixin, self).begin)
+
+    def _reconnect(self, func, *args, **kwargs):
         try:
-            return super(ReconnectMixin, self).execute_sql(sql, params)
+            return func(*args, **kwargs)
         except Exception as exc:
             # If we are in a transaction, do not reconnect silently as
             # any changes could be lost.
@@ -275,7 +281,7 @@ class ReconnectMixin(object):
                 self.close()
                 self.connect()
 
-            return super(ReconnectMixin, self).execute_sql(sql, params)
+            return func(*args, **kwargs)
 
 
 def resolve_multimodel_query(query, key='_model_identifier'):


### PR DESCRIPTION
**The Problem:**
`playhouse.shortcuts.ReconnectMixin` only supports reconnecting on `execute_sql` calls. For applications that always start an event loop by opening a transaction, this is of no use as `begin` uses `execute` (unless you're SQLite).

**The Solution:**
Given that no transaction may have started when calling `begin` it's worth checking if the connection should be reestablished before surfacing the exception. For nested transactions, the current `in_transaction` check remains to not silently reconnect.

There is the case of SQLite that calls `execute_sql` from `begin` so the `_reconnect` function would be called twice. Not ideal, but also not a big deal.

Feedback welcome.