### PR TITLE
Fix SyntaxWarning: invalid escape sequence

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -668,7 +668,7 @@ class SqliteMigrator(SchemaMigrator):
     SQLite supports a subset of ALTER TABLE queries, view the docs for the
     full details http://sqlite.org/lang_altertable.html
     """
-    column_re = re.compile('(.+?)\((.+)\)')
+    column_re = re.compile(r'(.+?)\((.+)\)')
     column_split_re = re.compile(r'(?:[^,(]|\([^)]*\))+')
     column_name_re = re.compile(r'''["`']?([\w]+)''')
     fk_re = re.compile(r'FOREIGN KEY\s+\("?([\w]+)"?\)\s+', re.I)
@@ -825,7 +825,7 @@ class SqliteMigrator(SchemaMigrator):
         # Strip out any junk after the column name.
         clean = []
         for column in columns:
-            if re.match('%s(?:[\'"`\]]?\s|$)' % column_to_update, column):
+            if re.match(r'%s(?:[\'"`\]]?\s|$)' % column_to_update, column):
                 column = new_column + column[len(column_to_update):]
             clean.append(column)
 

--- a/playhouse/reflection.py
+++ b/playhouse/reflection.py
@@ -419,13 +419,13 @@ class SqliteMetadata(Metadata):
         'varchar': CharField,
     }
 
-    begin = '(?:["\[\(]+)?'
-    end = '(?:["\]\)]+)?'
+    begin = r'(?:["\[\(]+)?'
+    end = r'(?:["\]\)]+)?'
     re_foreign_key = (
-        '(?:FOREIGN KEY\s*)?'
-        '{begin}(.+?){end}\s+(?:.+\s+)?'
-        'references\s+{begin}(.+?){end}'
-        '\s*\(["|\[]?(.+?)["|\]]?\)').format(begin=begin, end=end)
+        r'(?:FOREIGN KEY\s*)?'
+        r'{begin}(.+?){end}\s+(?:.+\s+)?'
+        r'references\s+{begin}(.+?){end}'
+        r'\s*\(["|\[]?(.+?)["|\]]?\)').format(begin=begin, end=end)
     re_varchar = r'^\s*(?:var)?char\s*\(\s*(\d+)\s*\)\s*$'
 
     def _map_col(self, column_type):
@@ -435,7 +435,7 @@ class SqliteMetadata(Metadata):
         elif re.search(self.re_varchar, raw_column_type):
             field_class = CharField
         else:
-            column_type = re.sub('\(.+\)', '', raw_column_type)
+            column_type = re.sub(r'\(.+\)', '', raw_column_type)
             if column_type == '':
                 field_class = BareField
             else:
@@ -847,7 +847,7 @@ def get_table_sql(model):
         sql = sql.replace(model._meta.database.param, '%s')
 
     # Format and indent the table declaration, simplest possible approach.
-    match_obj = re.match('^(.+?\()(.+)(\).*)', sql)
+    match_obj = re.match(r'^(.+?\()(.+)(\).*)', sql)
     create, columns, extra = match_obj.groups()
     indented = ',\n'.join('  %s' % column for column in columns.split(', '))
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -1386,7 +1386,7 @@ class TestWindowFunctions(BaseTestCase):
                 Register.value,
                 fn.SUM(Register.value).over(**over_kwargs))
             sql, params = __sql__(query)
-            match_obj = re.search('OVER \((.*?)\) FROM', sql)
+            match_obj = re.search(r'OVER \((.*?)\) FROM', sql)
             self.assertTrue(match_obj is not None)
             self.assertEqual(match_obj.groups()[0], expected)
             self.assertEqual(params, [])

--- a/tests/sqlite.py
+++ b/tests/sqlite.py
@@ -287,7 +287,7 @@ class TestTableFunction(BaseTestCase):
             'foo 123 45 bar 678 nuggie 9.0',
             ['123', '45', '678', '9', '0'])
         assertResults(
-            '[\w]+@[\w]+\.[\w]{2,3}',
+            r'[\w]+@[\w]+\.[\w]{2,3}',
             ('Dear charlie@example.com, this is nug@baz.com. I am writing on '
              'behalf of zaizee@foo.io. He dislikes your blog.'),
             ['charlie@example.com', 'nug@baz.com', 'zaizee@foo.io'])
@@ -314,7 +314,7 @@ class TestTableFunction(BaseTestCase):
                      messages)
         cur = self.execute('select posts.id, regex_search.rowid, regex_search.match '
                            'FROM posts, regex_search(?, posts.msg)',
-                           ('[\w]+@[\w]+\.\w{2,3}',))
+                           (r'[\w]+@[\w]+\.\w{2,3}',))
         results = cur.fetchall()
         self.assertEqual(results, [
             (1, 1, 'foo@example.fap'),


### PR DESCRIPTION
Fixes majority of
```
SyntaxWarning: invalid escape sequence '\('
```

PS: There is one false positive at https://github.com/coleifer/peewee/blob/8e539def877b6f3efe094e7e15434795bcbc7f19/tests/__init__.py#L79