### PR TITLE
add database table column default value

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -342,7 +342,6 @@ class SchemaMigrator(object):
         if not field.null:
             operations.extend([
                 self.apply_default(table, column_name, field),
-                self.add_column_default(table, column_name, field),
                 self.add_not_null(table, column_name)])
 
         if is_foreign_key and self.explicit_create_foreign_key:
@@ -359,6 +358,9 @@ class SchemaMigrator(object):
             using = getattr(field, 'index_type', None)
             operations.append(self.add_index(table, (column_name,),
                                              field.unique, using))
+            
+        if not field.default is None:
+            operations.append(self.add_column_default(table, column_name, field))
 
         return operations
 


### PR DESCRIPTION
In special scenarios, data is not written through Peewee, and there are compatibility issues with writing data.

for example:
> Mainly rolled back after software version upgrade, without deleting new fields, 
> without default values can result in data write failure.

E.g:
```python
class DemoModel(Model):
    name = CharField()
    new_demo_test = IntegerField(default=0)
    
    class Meta:
        database = database
        table_name = 'demo'
```

