### PR TITLE
Remove deprecated reconnect argument from MySQL ping.

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4228,7 +4228,7 @@ class MySQLDatabase(Database):
         conn = self._state.conn
         if hasattr(conn, 'ping'):
             try:
-                conn.ping(False)
+                conn.ping()
             except Exception:
                 return False
         return True

--- a/playhouse/pool.py
+++ b/playhouse/pool.py
@@ -260,7 +260,7 @@ class PooledDatabase(object):
 class PooledMySQLDatabase(PooledDatabase, MySQLDatabase):
     def _is_closed(self, conn):
         try:
-            conn.ping(False)
+            conn.ping()
         except:
             return True
         else:


### PR DESCRIPTION
Since MySQL 8.0.34, automatic reconnection has been deprecated, and even providing the argument as False (default) will result in deprecation warnings.

There is a MySQL issue open (but perhaps never to be fixed) about this new deprecation warning, which in our environment results in millions of useless log messages due to the Peewee connection pool is_closed check: https://bugs.mysql.com/bug.php?id=112089

MySQL deprecation note: https://dev.mysql.com/doc/c-api/8.0/en/c-api-auto-reconnect.html

PyMySQL discussion here: https://github.com/PyMySQL/mysqlclient/discussions/651

SQLAlchemy has solved this in a rather more complicated way, by introspecting the MySQL connection library to see if it supports a boolean argument and then using it if yes, otherwise no: https://gerrit.sqlalchemy.org/c/sqlalchemy/sqlalchemy/+/4926 (see also https://github.com/sqlalchemy/sqlalchemy/issues/10492).

I guess the Peewee solution could also be attempted with maximum backward compatibility, but I am not sure if there are enough users who would notice the difference, given the default behavior is to disable auto reconnection. Additionally, I expect the people using PooledMySQLDatabase would be even less likely to want auto reconnection on the MySQL client layer, since the connection pool should handle that.
