### PR TITLE
Add missing python_value for Postgres JSON field.

### DIFF
--- a/playhouse/postgres_ext.py
+++ b/playhouse/postgres_ext.py
@@ -299,9 +299,17 @@ class JSONField(Field):
     field_type = 'JSON'
     _json_datatype = 'json'
 
-    def __init__(self, dumps=None, *args, **kwargs):
+    def __init__(self, dumps=None, loads=None, *args, **kwargs):
         self.dumps = dumps or json.dumps
+        self.loads = loads or json.loads
         super(JSONField, self).__init__(*args, **kwargs)
+
+    def python_value(self, value):
+        if value is not None:
+            try:
+                return self.loads(value)
+            except (TypeError, ValueError):
+                return value
 
     def db_value(self, value):
         if value is None:


### PR DESCRIPTION
I have a need to use table.thaw on a postgres table with a JSON field. The thaw does not work correctly, JSON is inserted as a string and the quotation marks are escaped. I compared postgres to other JSON fields for other database drivers and found there was no python_value method as there was for MySQL and sqlite.

This pull request adds this missing method (taken from MySQL extension)