### PR TITLE
Resolve regex library warnings

### DIFF
--- a/playhouse/migrate.py
+++ b/playhouse/migrate.py
@@ -912,7 +912,7 @@ class SqliteMigrator(SchemaMigrator):
     @operation
     def drop_column_default(self, table, column):
         def _drop_default(column_name, column_def):
-            col = re.sub(r'DEFAULT\s+[\w"\'\(\)]+(\s|$)', '', column_def, re.I)
+            col = re.sub(r'DEFAULT\s+[\w"\'\(\)]+(\s|$)', '', column_def, flags=re.I)
             return col.strip()
         return self._update_column(table, column, _drop_default)
 


### PR DESCRIPTION
## PR Summary
This small PR resolves the regex library warnings:
```python
/tmp/peewee/playhouse/migrate.py:915: DeprecationWarning: 'count' is passed as positional argument
```