### PR TITLE
fix(pwiz): prevent escape sequences in SQLite codegen

### DIFF
--- a/pwiz.py
+++ b/pwiz.py
@@ -209,6 +209,7 @@ if __name__ == '__main__':
 
     connect = get_connect_kwargs(options)
     database = args[-1]
+    database = database.replace("\\","/")
 
     tables = None
     if options.tables:


### PR DESCRIPTION
Avoid unintended escape sequences (e.g. \t, \n) when:
- Command-line args contain backslashes
- Database name starts with 't' or 'n' etc.