### PR TITLE
Add support for ClickHouse

### DIFF
--- a/playhouse/clickhouse.py
+++ b/playhouse/clickhouse.py
@@ -1,0 +1,10 @@
+from peewee import *
+
+class ClickHouseDatabase(Database):
+    param = "%s"
+
+    def _connect(self):
+        return Connection(database=self.database, **self.connect_params)
+
+    def last_insert_id(self, cursor, query_type=None):
+        return None

--- a/playhouse/clickhouse.py
+++ b/playhouse/clickhouse.py
@@ -1,4 +1,6 @@
 from peewee import *
+from clickhouse_connect.dbapi.connection import Connection
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import String
 
 class ClickHouseDatabase(Database):
     param = "%s"
@@ -8,3 +10,6 @@ class ClickHouseDatabase(Database):
 
     def last_insert_id(self, cursor, query_type=None):
         return None
+
+    def get_binary_type(self):
+        return String

--- a/playhouse/clickhouse.py
+++ b/playhouse/clickhouse.py
@@ -1,12 +1,14 @@
-from peewee import *
 from clickhouse_connect.dbapi.connection import Connection
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import String
+from peewee import Database
 
 
 class ClickHouseDatabase(Database):
     param = "%s"
+    quote = '``'
 
     def _connect(self):
+        # Ignore CREATE INDEX for SQL compatibility
         self.connect_params["allow_create_index_without_type"] = 1
         self.connect_params["create_index_ignore_unique"] = 1
 
@@ -17,3 +19,8 @@ class ClickHouseDatabase(Database):
 
     def get_binary_type(self):
         return String
+
+    def get_tables(self, schema=None):
+        schema = schema or "main"
+        cursor = self.execute_sql('SHOW TABLES FROM "%s" ORDER BY name', (schema,))
+        return [row for row, in cursor.fetchall()]

--- a/playhouse/clickhouse.py
+++ b/playhouse/clickhouse.py
@@ -2,10 +2,14 @@ from peewee import *
 from clickhouse_connect.dbapi.connection import Connection
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import String
 
+
 class ClickHouseDatabase(Database):
     param = "%s"
 
     def _connect(self):
+        self.connect_params["allow_create_index_without_type"] = 1
+        self.connect_params["create_index_ignore_unique"] = 1
+
         return Connection(database=self.database, **self.connect_params)
 
     def last_insert_id(self, cursor, query_type=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ psycopg3 = ["psycopg[binary]"]
 aiosqlite = ["aiosqlite ", "greenlet"]
 aiomysql = ["aiomysql", "greenlet"]
 asyncpg = ["asyncpg ", "greenlet"]
+clickhouse = ["clickhouse-connect"]
 
 [tool.setuptools]
 packages = ["playhouse", "playhouse._pysqlite"]

--- a/runtests.py
+++ b/runtests.py
@@ -24,7 +24,7 @@ def get_option_parser():
         dest='engine',
         help=('Database engine to test, one of '
               '[sqlite, postgres, mysql, mysqlconnector, apsw, sqlcipher,'
-              ' cockroachdb, psycopg3]'))
+              ' cockroachdb, psycopg3, clickhouse]'))
     basic.add_option('-v', '--verbosity', dest='verbosity', default=1,
                      type='int', help='Verbosity of output')
     basic.add_option('-f', '--failfast', action='store_true', default=False,
@@ -55,6 +55,12 @@ def get_option_parser():
             ('host', 'localhost', 'localhost'),
             ('port', '26257', ''),
             ('user', 'root', 'root'),
+            ('password', 'blank', ''))),
+        ('ClickHouse', 'CH', (
+            # param  default disp default val
+            ('host', 'localhost', 'localhost'),
+            ('port', '8123', ''),
+            ('user', 'default', 'default'),
             ('password', 'blank', ''))))
     for name, prefix, param_list in db_param_map:
         group = optparse.OptionGroup(parser, '%s connection options' % name)

--- a/tests/base.py
+++ b/tests/base.py
@@ -12,6 +12,7 @@ except ImportError:
 
 from peewee import *
 from peewee import sqlite3
+from playhouse.clickhouse import ClickHouseDatabase
 from playhouse.cockroachdb import CockroachDatabase
 from playhouse.cockroachdb import NESTED_TX_MIN_VERSION
 from playhouse.mysql_ext import MariaDBConnectorDatabase
@@ -32,6 +33,7 @@ def db_loader(engine, name='peewee_test', db_class=None, **params):
             MySQLConnectorDatabase: ['mysqlconnector'],
             MariaDBConnectorDatabase: ['mariadb', 'maridbconnector'],
             CockroachDatabase: ['cockroach', 'cockroachdb', 'crdb'],
+            ClickHouseDatabase: ['clickhouse'],
         }
         engine_map = dict((alias, db) for db, aliases in engine_aliases.items()
                           for alias in aliases)
@@ -62,6 +64,7 @@ IS_MYSQL = BACKEND.startswith(('mysql', 'maria'))
 IS_POSTGRESQL = BACKEND.startswith(('postgres', 'psycopg'))
 IS_CRDB = BACKEND in ('cockroach', 'cockroachdb', 'crdb')
 IS_PSYCOPG3 = BACKEND == 'psycopg3'
+IS_CH = BACKEND == 'clickhouse'
 
 
 def make_db_params(key):

--- a/tests/db_tests.py
+++ b/tests/db_tests.py
@@ -15,6 +15,7 @@ from peewee import sort_models
 
 from .base import BaseTestCase
 from .base import DatabaseTestCase
+from .base import IS_CH
 from .base import IS_CRDB
 from .base import IS_MYSQL
 from .base import IS_POSTGRESQL


### PR DESCRIPTION
Hello.  [A while ago](https://github.com/coleifer/peewee/issues/2435) there were some difficulties adding a driver for [ClickHouse](https://clickhouse.com/) using `clickhouse-driver`.  Now that there is an [official Python client](https://github.com/ClickHouse/clickhouse-connect) for ClickHouse that supports DB-API 2.0, including the binding of parameters using sequences, I think it should be possible to support ClickHouse now.

So far I've only got a basic `ClickHouseDatabase` class implemented.  It can pass a few tests, and it can run the anomaly_detection example with minimum changes.

To make this useful quickly I think it is best to emphasize the support of Create and Read operations, and support the field types that are useful such as JSON, because ClickHouse handles Update and Delete rather differently from other RDBMS.  I would love to hear your thoughts on this, and the likelihood of having this PR merged, so we can set a reasonable goal for it.  Thanks.