### PR TITLE
Fix MySQL connection parameter name

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4390,7 +4390,7 @@ class MySQLDatabase(Database):
     def _connect(self):
         if mysql is None:
             raise ImproperlyConfigured('MySQL driver not installed!')
-        conn = mysql.connect(db=self.database, autocommit=True,
+        conn = mysql.connect(database=self.database, autocommit=True,
                              **self.connect_params)
         return conn
 


### PR DESCRIPTION
replace the deprecated db keyword argument with the database one.

Refers to #3049