### PR TITLE
Fix model_to_dict with lazy foreign keys

### DIFF
--- a/playhouse/shortcuts.py
+++ b/playhouse/shortcuts.py
@@ -1,7 +1,7 @@
 import threading
 
 from peewee import *
-from peewee import Alias
+from peewee import Alias, Field
 from peewee import CompoundSelectQuery
 from peewee import Metadata
 from peewee import callable_
@@ -76,7 +76,9 @@ def model_to_dict(model, recurse=True, backrefs=False, only=None,
             continue
 
         field_data = model.__data__.get(field.name)
-        if isinstance(field, ForeignKeyField) and recurse:
+        if isinstance(field_data, int) and field.lazy_load is False:
+            data[field.column_name] = field_data
+        elif isinstance(field, ForeignKeyField) and recurse:
             if field_data is not None:
                 rel_obj = getattr(model, field.name)
                 field_data = model_to_dict(


### PR DESCRIPTION
Handle raw integer values for ForeignKeyField declarations that use lazy_load=False in model_to_dict().\n\nThis preserves the foreign-key column value without triggering relation serialization.\n\nTests: not run after amending to the original submitted change.