### PR TITLE
Escape double quotes in table names in SQLite introspection

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -4259,7 +4259,7 @@ class SqliteDatabase(Database):
         # Determine which indexes have a unique constraint.
         unique_indexes = set()
         cursor = self.execute_sql('PRAGMA "%s".index_list("%s")' %
-                                  (schema, table))
+                                  (schema, table.replace('"', '""')))
         for row in cursor.fetchall():
             name = row[1]
             is_unique = int(row[2]) == 1
@@ -4285,20 +4285,20 @@ class SqliteDatabase(Database):
     def get_columns(self, table, schema=None):
         schema = (schema or 'main').replace('"', '""')
         cursor = self.execute_sql('PRAGMA "%s".table_info("%s")' %
-                                  (schema, table))
+                                  (schema, table.replace('"', '""')))
         return [ColumnMetadata(r[1], r[2], not r[3], bool(r[5]), table, r[4])
                 for r in cursor.fetchall()]
 
     def get_primary_keys(self, table, schema=None):
         schema = (schema or 'main').replace('"', '""')
         cursor = self.execute_sql('PRAGMA "%s".table_info("%s")' %
-                                  (schema, table))
+                                  (schema, table.replace('"', '""')))
         return [row[1] for row in filter(lambda r: r[-1], cursor.fetchall())]
 
     def get_foreign_keys(self, table, schema=None):
         schema = (schema or 'main').replace('"', '""')
         cursor = self.execute_sql('PRAGMA "%s".foreign_key_list("%s")' %
-                                  (schema, table))
+                                  (schema, table.replace('"', '""')))
         return [ForeignKeyMetadata(row[3], row[2], row[4], table)
                 for row in cursor.fetchall()]
 

--- a/tests/db_tests.py
+++ b/tests/db_tests.py
@@ -44,6 +44,7 @@ from .base import get_sqlite_db
 from .base import new_connection
 from .base import requires_models
 from .base import requires_postgresql
+from .base import requires_sqlite
 from .base import slow_test
 from .base_models import Category
 from .base_models import Person
@@ -575,6 +576,30 @@ class TestIntrospection(ModelTestCase):
                 for fk in foreign_keys]
         self.assertEqual(data, [
             ('parent_id', 'category', 'name', 'category')])
+
+    @requires_sqlite
+    def test_introspect_quoted_table_name(self):
+        # The table name is interpolated into the PRAGMA introspection
+        # statements, so an embedded double-quote must be escaped just like the
+        # schema name is in these same methods (and the table name is in the
+        # MySQL introspection). Without escaping the quote breaks out of the
+        # identifier and the PRAGMA fails with a syntax error.
+        self.database.execute_sql(
+            'CREATE TABLE "tbl""q" ("id" INTEGER NOT NULL PRIMARY KEY, '
+            '"v" TEXT)')
+        self.database.execute_sql('CREATE INDEX "tbl_q_v" ON "tbl""q" ("v")')
+        try:
+            columns = self.database.get_columns('tbl"q')
+            self.assertEqual([c.name for c in columns], ['id', 'v'])
+
+            self.assertEqual(self.database.get_primary_keys('tbl"q'), ['id'])
+
+            indexes = self.database.get_indexes('tbl"q')
+            self.assertEqual([i.name for i in indexes], ['tbl_q_v'])
+
+            self.assertEqual(self.database.get_foreign_keys('tbl"q'), [])
+        finally:
+            self.database.execute_sql('DROP TABLE "tbl""q"')
 
 
 # ===========================================================================


### PR DESCRIPTION
The SQLite introspection methods interpolate the table name straight into the `PRAGMA` statement without escaping an embedded double quote:

```python
cursor = self.execute_sql('PRAGMA "%s".table_info("%s")' % (schema, table))
```

c2cf25157 added double-quote escaping for the `schema` name in these same methods, and `MySQLDatabase.get_indexes`/`get_primary_keys` already escape the interpolated table name before `SHOW INDEX FROM`. The table name in the SQLite methods was the one identifier left unescaped, so a name containing a `"` breaks out of the quoted identifier:

```
PRAGMA "main".table_info("a"b")   ->  OperationalError: near "b": syntax error
```

This affects `get_indexes`, `get_columns`, `get_primary_keys` and `get_foreign_keys`. The fix escapes the name where it is interpolated, matching the existing `schema` escaping. It is applied at the interpolation site rather than by reassigning `table`, because these methods also pass the raw name as a bound parameter (`get_indexes`) and return it in the metadata (`get_columns`, `get_foreign_keys`).

Added a SQLite regression test that introspects a table whose name contains a `"`. It fails on master with the syntax error shown above and passes with the change. `tests/db_tests.py` introspection, reflection and migration tests stay green.
