### PR TITLE
Fix missing OverflowError in IntegerField and FloatField adapt()

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -5564,7 +5564,7 @@ class IntegerField(Field):
     def adapt(self, value):
         try:
             return int(value)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
             return value
 
 
@@ -5614,7 +5614,7 @@ class FloatField(Field):
     def adapt(self, value):
         try:
             return float(value)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
             return value
 
 


### PR DESCRIPTION
`int(float('inf'))` raises `OverflowError`, not `ValueError` or `TypeError`. Similarly, `float(10**10000)` raises `OverflowError: int too large to convert to float`.

Both `IntegerField.adapt()` and `FloatField.adapt()` currently catch only `(ValueError, TypeError)`, so passing extreme values propagates an unhandled `OverflowError` instead of returning the original value gracefully.

**Fix:** Add `OverflowError` to the except tuple in both methods.

Reproduction:
```python
from peewee import IntegerField, FloatField
IntegerField().adapt(float('inf'))  # OverflowError: cannot convert float infinity to integer
FloatField().adapt(10**10000)       # OverflowError: int too large to convert to float
```