### PR TITLE
Wrap a plain compound member with its own ORDER BY/LIMIT under SQLite

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -2464,10 +2464,14 @@ class CompoundSelectQuery(SelectBase):
         csq_setting = ctx.state.compound_select_parentheses
 
         if not csq_setting or csq_setting == CSQ_PARENTHESES_NEVER:
-            # Parens are not allowed here (sqlite), wrap a nested compound
-            # that needs grouping as a subquery instead.
-            if (isinstance(subq, CompoundSelectQuery)
-                    and self._needs_group(subq, lhs)):
+            # Parens are not allowed here (sqlite), wrap a member that needs
+            # grouping as a subquery instead: a nested compound, or a plain
+            # member with its own ORDER BY / LIMIT / OFFSET (written flat those
+            # would apply to the whole statement).
+            if isinstance(subq, CompoundSelectQuery):
+                if self._needs_group(subq, lhs):
+                    return CSQ_WRAP
+            elif self._self_wraps(subq):
                 return CSQ_WRAP
         elif csq_setting == CSQ_PARENTHESES_ALWAYS:
             return CSQ_PARENS

--- a/tests/model_sql.py
+++ b/tests/model_sql.py
@@ -1948,12 +1948,16 @@ class TestModelCompoundSelect(BaseTestCase):
         lhs = Alpha.select(Alpha.alpha).order_by(Alpha.alpha).limit(3)
         rhs = Beta.select(Beta.beta).order_by(Beta.beta).limit(4)
         compound = (lhs | rhs).limit(5)
-        # This may be invalid SQL, but this at least documents the behavior.
+        # Each member carries its own ORDER BY / LIMIT, so it is wrapped as a
+        # subquery (CSQ never / sqlite) to keep that ordering from rebinding to
+        # the whole statement.
         self.assertSQL(compound, (
+            'SELECT * FROM ('
             'SELECT "t1"."alpha" FROM "alpha" AS "t1" '
-            'ORDER BY "t1"."alpha" LIMIT ? UNION '
+            'ORDER BY "t1"."alpha" LIMIT ?) UNION '
+            'SELECT * FROM ('
             'SELECT "t2"."beta" FROM "beta" AS "t2" '
-            'ORDER BY "t2"."beta" LIMIT ? LIMIT ?'), [3, 4, 5])
+            'ORDER BY "t2"."beta" LIMIT ?) LIMIT ?'), [3, 4, 5])
 
     def test_union_from(self):
         lhs = Alpha.select(Alpha.alpha).where(Alpha.alpha < 2)

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -1391,6 +1391,46 @@ class TestSelectQuery(BaseTestCase):
             'WHERE ("t1"."value" = ?))))'), [5, 2, 4],
             compound_select_parentheses=3)  # Grouped.
 
+    def test_compound_member_order_limit(self):
+        # A plain (non-compound) member with its own ORDER BY / LIMIT must be
+        # grouped, exactly like a nested compound member: written flat under
+        # CSQ never (sqlite) an lhs is a syntax error and an rhs silently
+        # rebinds the ORDER BY / LIMIT to the whole statement.
+        Reg = Table('register', ('value',))
+        a = Reg.select().where(Reg.value < 5).order_by(Reg.value.desc()).limit(2)
+        b = Reg.select().where(Reg.value > 2)
+
+        # CSQ never (sqlite): wrap the ordered/limited member as a subquery.
+        self.assertSQL(a | b, (
+            'SELECT * FROM ('
+            'SELECT "t1"."value" FROM "register" AS "t1" '
+            'WHERE ("t1"."value" < ?) '
+            'ORDER BY "t1"."value" DESC LIMIT ?) '
+            'UNION '
+            'SELECT "t2"."value" FROM "register" AS "t2" '
+            'WHERE ("t2"."value" > ?)'), [5, 2, 2],
+            compound_select_parentheses=0)  # Never.
+
+        self.assertSQL(b | a, (
+            'SELECT "t1"."value" FROM "register" AS "t1" '
+            'WHERE ("t1"."value" > ?) '
+            'UNION '
+            'SELECT * FROM ('
+            'SELECT "t2"."value" FROM "register" AS "t2" '
+            'WHERE ("t2"."value" < ?) '
+            'ORDER BY "t2"."value" DESC LIMIT ?)'), [2, 5, 2],
+            compound_select_parentheses=0)  # Never.
+
+        # CSQ always (postgres): the member gets ordinary parentheses.
+        self.assertSQL(a | b, (
+            '(SELECT "t1"."value" FROM "register" AS "t1" '
+            'WHERE ("t1"."value" < ?) '
+            'ORDER BY "t1"."value" DESC LIMIT ?) '
+            'UNION '
+            '(SELECT "t2"."value" FROM "register" AS "t2" '
+            'WHERE ("t2"."value" > ?))'), [5, 2, 2],
+            compound_select_parentheses=1)  # Always.
+
     def test_compound_select_order_limit(self):
         A = Table('a', ('col_a',))
         B = Table('b', ('col_b',))


### PR DESCRIPTION
The subquery-wrapping recently added for `CSQ_PARENTHESES_NEVER` (SQLite) only wraps a member that is itself a nested `CompoundSelectQuery`. A **plain `Select` member** carrying its own `ORDER BY`/`LIMIT`/`OFFSET` is left un-wrapped, so it emits invalid SQL:

```python
db = SqliteDatabase(':memory:')   # model P(name, score)
top2 = P.select(P.name).order_by(P.name).limit(2)
comp = top2 | P.select(P.name).where(P.score == 5)

list(comp)
# SELECT ... ORDER BY "t1"."name" LIMIT ? UNION SELECT ...
# OperationalError: ORDER BY clause should come after UNION not before
```

As an **lhs** member it raises on execution; as an **rhs** member the `ORDER BY`/`LIMIT` silently binds to the whole union instead of the member, so the results are wrong. Every other dialect (ALWAYS/UNNESTED/GROUPED) already parenthesizes the member correctly — only the SQLite `NEVER` path is affected.

This is one case short of the wrapping mechanism itself: `_member_style` handles a nested compound member (`_needs_group` → `CSQ_WRAP`) but never consults `_self_wraps` for a plain member. `test_nested_compound_grouping` already documents the intent ("an lhs with its own ORDER BY / LIMIT must be wrapped, written flat those would apply to the whole statement"), and `test_limit`'s own comment noted its output "may be invalid SQL" — this completes both.

**Fix**: also wrap a plain member that `_self_wraps` (has its own ORDER BY/LIMIT/OFFSET) as `SELECT * FROM (...)`. `_needs_group` is intentionally not reused for plain members — it would over-wrap plain `EXCEPT`/`INTERSECT` rhs members.

**Verification** (re-runnable from the diff):
- Before: the lhs form raises `OperationalError`; the rhs form returns wrong rows.
- After: `SELECT * FROM (SELECT ... ORDER BY ... LIMIT ?) UNION ...` executes and returns the correct rows; OFFSET-only members likewise; ALWAYS/UNNESTED/GROUPED output is unchanged; plain `EXCEPT` rhs is not over-wrapped.
- Added `tests/sql.py::test_compound_member_order_limit` (fails on the current tree, passes with the fix) and updated `test_limit` (whose comment flagged its output as possibly-invalid) to the now-valid wrapped SQL. `python runtests.py` → 1681 tests OK.

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the tests, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
