### PR TITLE
Add 'null' field to _FieldKwargs type

### DIFF
--- a/peewee-stubs/__init__.pyi
+++ b/peewee-stubs/__init__.pyi
@@ -24,6 +24,7 @@ _DatabaseType: TypeAlias = Database | DatabaseProxy
 # Common field kwargs, Unpack-ed into the field __new__ overloads.
 @type_check_only
 class _FieldKwargs(TypedDict, total=False):
+    null: bool
     index: bool
     unique: bool
     primary_key: bool


### PR DESCRIPTION
In the following example containing self-referential FKs, mypy complains about finding no overload variant for ForeignKeyField:
```python
from peewee import ForeignKeyField, Model

class Human(Model):
    parent = ForeignKeyField("self", null=False)
```
With the proposed update, the warning disappears.
It seems like `null` was missed in the list of inputs for the `Field.__init__` method although the input is defined in the [actual implementation code](https://docs.peewee-orm.com/en/latest/peewee/api.html#Field).