### PR TITLE
Do not apply type parameters to bare fields

### DIFF
--- a/playhouse/reflection.py
+++ b/playhouse/reflection.py
@@ -805,7 +805,9 @@ class Introspector(object):
                 params = {
                     'column_name': column_name,
                     'null': column.nullable}
-                if column.extra_parameters is not None:
+                if column.extra_parameters is not None and \
+                   FieldClass is not BareField:
+                    # e.g. max_length does not apply to BareField.
                     params.update(column.extra_parameters)
                 if column.primary_key and composite_key:
                     if FieldClass is AutoField:

--- a/tests/reflection.py
+++ b/tests/reflection.py
@@ -723,6 +723,12 @@ class TestReflectionFacets(BaseReflectionTestCase):
         self.assertEqual(F.dec.max_digits, 10)
         self.assertEqual(F.dec.decimal_places, 2)
 
+    def test_bare_fields_type_parameters(self):
+        models = self.introspector.generate_models(bare_fields=True)
+        F = models[Facets._meta.table_name]
+        self.assertTrue(type(F.char50) is BareField)
+        self.assertTrue(type(F.dec) is BareField)
+
     def test_field_classes(self):
         models = self.introspector.generate_models()
         F = models[Facets._meta.table_name]


### PR DESCRIPTION
`generate_models(bare_fields=True)` raises `TypeError` on any table with a parameterized `VARCHAR(n)` column where n != 255:

```python
sqlite3.connect('t.db').executescript(
    'CREATE TABLE t (id INTEGER PRIMARY KEY, name VARCHAR(64));')

DataSet('sqlite:///t.db', bare_fields=True).tables
# TypeError: Field.__init__() got an unexpected keyword argument 'max_length'
```

`generate_models` substitutes `BareField` for the introspected field class, then applies the parameters recovered by `_extract_type_params`, which `BareField` does not accept. This is the same reasoning behind the existing `extra_parameters = None  # e.g. max_length does not apply to FK.` for foreign keys.

Introduced in 4.1.2 by bf776f53; 4.1.1 is unaffected. `pwiz` has no bare-fields mode, so the code generation path does not need the same guard.

sqlite-web calls `SqliteDataSet(db, bare_fields=True)`, so it currently fails to start against most databases when installed with peewee >= 4.1.2.

Added a test to `TestReflectionFacets` that fails without the change. Full suite passes (1705 tests, sqlite).