### PR TITLE
Fix JSONField when the database proxy is initialized before the model

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -5872,14 +5872,13 @@ class FieldDatabaseHook(object):
         raise NotImplementedError('Subclasses must implement')
 
     def bind(self, model, name, set_attribute=True):
-        if model._meta.database is not None:
-            if isinstance(model._meta.database, Proxy):
-                model._meta.database.attach_callback(self._db_hook)
-                self._db_hook(None)
-            else:
-                self._db_hook(model._meta.database)
-        else:
-            self._db_hook(None)
+        database = model._meta.database
+        if isinstance(database, Proxy):
+            database.attach_callback(self._db_hook)
+            # An uninitialized proxy is treated as None.
+            if database.obj is None:
+                database = None
+        self._db_hook(database)
 
         # Attach a hook to the model metadata; in the event the database is
         # changed or set at run-time, we will be sure to apply our callback and

--- a/tests/json_field.py
+++ b/tests/json_field.py
@@ -461,6 +461,25 @@ class TestDeferredDatabase(ModelTestCase):
         finally:
             PM.drop_table()
 
+    def test_proxy_initialized_before_model(self):
+        proxy = Proxy()
+        proxy.initialize(db)
+
+        class PM(TestModel):
+            data = JSONField(null=True)
+            class Meta:
+                database = proxy
+
+        # Already initialized, so there is no later callback to wait for.
+        self.assertIsNotNone(PM.data._helper)
+
+        PM.create_table()
+        try:
+            PM.create(data={'k': [1, 2]})
+            self.assertEqual(PM.select().first().data, {'k': [1, 2]})
+        finally:
+            PM.drop_table()
+
 
 @skip_if(SKIP_PATHS, 'requires SQLite 3.38 or non-SQLite backend')
 class TestInheritedJSONField(ModelTestCase):


### PR DESCRIPTION
Hit this with the proxy initialised before the models module gets imported. Every `JSONField` on those models quietly stopped working.

```python
proxy = DatabaseProxy()
proxy.initialize(SqliteDatabase(':memory:'))  # swap these two round and it's fine

class Note(Model):
    data = JSONField()
    class Meta:
        database = proxy

Note.create(data={'k': 1})
# peewee.ProgrammingError: Error binding parameter 1: type 'dict' is not supported
```

`Note.data['k']` gives `AttributeError: 'NoneType' object has no attribute 'extract'`, and scalars are worse - `data='hello'` stores the bare text with no error at all, so `json_valid()` on the column comes back 0.

`attach_callback()` only appends, so a proxy thats already initialised never fires the hook, and `bind()` was passing `None` either way. `Metadata.set_database()` already only nulls a proxy when `obj is None`, so I've made `bind()` do the same.

Only bites since JSONField moved onto that hook - BlobField's fallback was `bytearray`, which every driver takes.

Tested on sqlite only (`python runtests.py`, 1826 pass). The postgres and mysql helpers go through the same hook so I'd expect those fine, but I've not run them.
