### PR TITLE
Support utc offsets in TimeField

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -6250,6 +6250,8 @@ class TimeField(_BaseFormattedField):
         '%H:%M:%S.%f',
         '%H:%M:%S',
         '%H:%M',
+        '%H:%M:%S.%f%z',
+        '%H:%M:%S%z',
         '%Y-%m-%d %H:%M:%S.%f',
         '%Y-%m-%d %H:%M:%S',
     ]
@@ -6257,7 +6259,7 @@ class TimeField(_BaseFormattedField):
     def adapt(self, value):
         if value:
             if isinstance(value, str):
-                pp = lambda x: x.time()
+                pp = lambda x: x.timetz()
                 return format_date_time(value, self.formats, pp)
             elif isinstance(value, datetime.datetime):
                 return value.time()

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -462,6 +462,32 @@ class TestDateFields(ModelTestCase):
 
         self.assertEqual(format_date_time('not a date', []), 'not a date')
 
+    def test_time_utc_offset(self):
+        # TimeField accepts an offset wherever DateTimeField does.
+        tz = datetime.timezone(datetime.timedelta(hours=2))
+        for s, expected in (
+                ('11:12:13+02:00', datetime.time(11, 12, 13, tzinfo=tz)),
+                ('11:12:13.123456+02:00',
+                 datetime.time(11, 12, 13, 123456, tzinfo=tz)),
+                ('11:12:13Z',
+                 datetime.time(11, 12, 13, tzinfo=datetime.timezone.utc)),
+                ('11:12:13', datetime.time(11, 12, 13))):
+            val = format_date_time(s, TimeField.formats, lambda x: x.timetz())
+            self.assertEqual(val, expected)
+            self.assertEqual(val.utcoffset(), expected.utcoffset())
+
+    def test_time_utc_offset_round_trip(self):
+        # A tz-aware time must come back as the same time, not as a str.
+        tz = datetime.timezone(datetime.timedelta(hours=2))
+        for t in (datetime.time(11, 12, 13, tzinfo=tz),
+                  datetime.time(11, 12, 13, 123456,
+                                tzinfo=datetime.timezone.utc),
+                  datetime.time(11, 12, 13)):
+            dm = DateModel.create(time=t)
+            dm_db = DateModel[dm.id]
+            self.assertEqual(dm_db.time, t)
+            self.assertEqual(dm_db.time.utcoffset(), t.utcoffset())
+
     def test_to_timestamp(self):
         dt = datetime.datetime(2019, 1, 2, 3, 4, 5)
         ts = calendar.timegm(dt.utctimetuple())


### PR DESCRIPTION
A tz-aware `datetime.time` does not survive a round trip — it comes back as a `str`:

```
in=datetime.time(12, 30, 45, tzinfo=timezone(timedelta(seconds=7200)))  raw='12:30:45+02:00'  out='12:30:45+02:00'  (str)
in=datetime.time(12, 30, 45, 123456, tzinfo=timezone.utc)               raw='12:30:45.123456+00:00'  out='12:30:45.123456+00:00'  (str)
in=datetime.time(12, 30, 45)                                            raw='12:30:45'  out=datetime.time(12, 30, 45)
```

`DateTimeField` handles the same offsets correctly. It got `'%Y-%m-%d %H:%M:%S.%f%z'` and
`'%Y-%m-%d %H:%M:%S%z'` in 38d637a5 ("Add support for utc offset..."), whose entire `peewee.py` diff
is those two lines; `TimeField.formats` 55 lines below was not updated. `datetime.fromisoformat`
never accepts a bare time string, so the ISO fast path in `format_date_time` cannot cover for it —
which also makes the `Z` → `+00:00` normalisation there dead code for `TimeField` today.

Adding the two `%z` formats is not enough on its own: `pp = lambda x: x.time()` drops the offset one
line later, so the post-process has to be `timetz()`. For a naive string `timetz()` is identical to
`time()`.

Two tests: one on `TimeField.formats` directly (offsets and `Z`), one full round trip through
`DateModel`.

**Mutants.** Reverting `peewee.py` against `origin/master` and keeping both tests fails both.
The naive fix — add the two formats, leave `.time()` — still fails the round-trip test, which is
what pins the `timetz()` half.

**Run:** `python3 runtests.py` on sqlite, Python 3.14.7 / sqlite 3.53.4 → `Ran 1873 tests … OK
(skipped=175)`; unmodified master is `Ran 1871 … OK (skipped=175)`. I did **not** run this against
MySQL or Postgres — no server here — so `TIMETZ`/`TIME(6)` behaviour on those backends is untested
by me.

AI assistance: found and drafted with Claude Code (Claude Opus 5, `claude-opus-5`), from a sweep for
value round trips that do not close — not from hitting it in production use.
